### PR TITLE
Fix reloading of auxiliary files

### DIFF
--- a/lib/camping/reloader.rb
+++ b/lib/camping/reloader.rb
@@ -53,6 +53,10 @@ module Camping
       # Loads the apps availble in this script.  Use <tt>apps</tt> to get
       # the loaded apps.
       def load_apps
+        @requires.each do |path|
+          $LOADED_FEATURES.delete(path)
+        end
+
         all_requires = $LOADED_FEATURES.dup
         all_apps = Camping::Apps.dup
         


### PR DESCRIPTION
If I have:
- an app in `foo.rb`
- an auxiliary file in `foo/bar.rb`
- a `require "foo/bar"` call in `foo.rb`

...then `bar.rb` doesn't get reloaded when it changes, because—even though the `mtime` is updated, and `foo.rb` is reloaded—`bar.rb` got added to `$LOADED_FEATURES` when it was first `require`d, and the `require "foo/bar"` call thus has no effect.

This patch makes `Camping::Reloader::Script#load_apps` delete all auxiliary file paths from `$LOADED_FEATURES` before reloading `foo.rb`, so that they are correctly reloaded.
