### PR TITLE
Rant about cookies in Camping + how I'd fix it

### DIFF
--- a/test/apps/new_cookies.rb
+++ b/test/apps/new_cookies.rb
@@ -1,0 +1,34 @@
+# coding: utf-8
+
+require 'camping-unabridged'
+
+
+Camping.goes :CookieTest
+module CookieTest::Controllers
+	class Index
+		def get
+			"Head to <a href='#{R TestSet}'>TestSet</a> to set cookies." +
+			'<br><br>' +
+			"Head to <a href='#{R TestGet}'>TestGet</a> to check them."
+		end
+	end
+	
+	class TestSet
+		def get
+			set_cookie :regular, 'val1'
+			@cookies[:trying_old_syntax] = 'val2' # this will print a warning to the console
+			set_cookie 'expiresin30s', 'val3', :expires=>30
+			set_cookie 'expiresv2', 'val4', :expires=>(Time.now+30)
+			set_cookie(:hashie, {:a => 5})
+			'OK.'
+		end
+	end
+	
+	class TestGet
+		def get
+			@cookies.cookies.inspect
+		end
+	end
+end
+
+


### PR DESCRIPTION
First - I do not expect anyone to just merge this and call it a day. This is just an example, and in current state it somewhat breaks backwards compatibility.

Second - is anybody actually here? If nobody responds, I'm just going to release my fork as a separate gem.

---

Currently cookies system in Camping is like this:

``` ruby
@cookies['name'] = 'value' # set
@cookies['name'] # get
```

The above horribly broken, and let me explain why:
- it confuses users - in reality, setting and reading cookies is _not_ the same thing, and people may get all sorts of wrong ideas seeing the above syntax if they don't know much about HTTP protocol itself;
- at first glance, it provides no way to, for example, set the expiration date of cookie, and I consider this an essential feature of cookies;
- after lots of digging, you find out that this works: `@cookies['name'] = {value: 'value', expires:(Time.now+60*60*24)}`. This is even worse; trying to read back the value during the request will yield the entire hash, but on subsequent request only the value itself. This forces you to write two versions of cookie-reading code, and once again gives all sorts of bad ideas, since after a cookie is set and sent to browser, the metadata like exp. date is not available.

---

Right. So obviously something has to be done. Instead of just complaining, I went ahead and did it.

New syntax:

``` ruby
set_cookie 'name', 'value' # set
set_cookie 'name', 'value', expires: 60*60*24, httponly: true # set
@cookies['name'] # get
```

("expires" option is special: if you pass it a numeric value, this is equivavalent to Time.now+value.)

Additionally:
- value can be any marshallable Ruby object (it is marshalled and unmarshalled transparently to the user)
- name being a string or symbol doesn't matter (it's resolved as the same thing)
- you can set all sorts of options
- and old setter syntax still works (although I made it generate a warning). However, I said earlier that this patch breaks backwards compatibility: it's not possible to write @cookies.name anymore (although it would be trivial to add this).

---

This commit doesn't include changes that have to be made in abridged camping.rb; I figured there's no point to work on it until somebody confirms that what I made makes sense. It does, instead, include a little test app.

So. Does it make sense?
