### PR TITLE
Fix response errors

### DIFF
--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -441,7 +441,8 @@ module Camping
     # Some magic in Camping can be performed by overriding this method.
     def service(*a)
       r = catch(:halt){send(@method, *a)}
-      @body ||= r 
+      @body ||= r
+      @body = @body.to_s if @body.nil? || !@body.respond_to?(:each)  
       self
     end
   end

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -30,7 +30,8 @@ r=@request=Rack:: Request.new(@env=env);@root,@input,@cookies,@state,@headers,
 @status,@method=r.script_name.sub(/\/$/,''),n(r.params),Cookies[r.cookies],
 H[r.session[SK]||{}],{'Content-Type'=>'text/html'},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=
-n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self
+n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;
+@body=@body.to_s if @body.nil? || !@body.respond_to?(:each); self
 end end;module Controllers;@r=[];class<<self;def R *u;r=@r;Class.
 new{meta_def(:urls){u};meta_def(:inherited){|x|r<<x}}end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]

--- a/test/app_simple.rb
+++ b/test/app_simple.rb
@@ -66,7 +66,7 @@ module Simple::Controllers
     end
   end
 
-  class IteratableResponse < R '/iter'
+  class IterableResponse < R '/iter'
     def get 
       [1,2,3]
     end
@@ -138,7 +138,7 @@ class Simple::Test < TestCase
     assert_equal "text/html", last_response.headers['Content-Type']
   end
 
-  def test_iteratable_response
+  def test_iterable_response
     get '/iter'
     assert_body "123"
     assert_equal "text/html", last_response.headers['Content-Type']

--- a/test/app_simple.rb
+++ b/test/app_simple.rb
@@ -53,6 +53,24 @@ module Simple::Controllers
       redirect MultipleComplexX, 'hello%#/world'
     end
   end
+
+  class NilResponse < R '/nil' 
+    def get
+      #nil response
+    end
+  end
+
+  class NotStringResponse < R '/notstring' 
+    def get
+      123
+    end
+  end
+
+  class IteratableResponse < R '/iter'
+    def get 
+      [1,2,3]
+    end
+  end
 end
 
 class Simple::Test < TestCase
@@ -106,5 +124,23 @@ class Simple::Test < TestCase
     get '/weird'
     follow_redirect!
     assert_body 'Complex: hello%#/world'
+  end
+
+  def test_nil_response 
+    get '/nil'
+    assert_body ""
+    assert_equal "text/html", last_response.headers['Content-Type']
+  end
+
+  def test_not_string_response
+    get '/notstring'
+    assert_body "123"
+    assert_equal "text/html", last_response.headers['Content-Type']
+  end
+
+  def test_iteratable_response
+    get '/iter'
+    assert_body "123"
+    assert_equal "text/html", last_response.headers['Content-Type']
   end
 end


### PR DESCRIPTION
Hi.

I fixed response bug. 
For example when you have controllers with methods, which return not String or not Iterable Object then you get error => `stringable or iterable required`.

Example 

```
 class Test
    #nil for response
    def get  
    end
 end
```

or 

```
class Test
  def get 
    123
  end
end
```
