### PR TITLE
deprecation warnings

### DIFF
--- a/lib/camping/ar.rb
+++ b/lib/camping/ar.rb
@@ -33,7 +33,7 @@ $AR_EXTRAS = %{
         end
       end
 
-      si = SchemaInfo.find(:first) || SchemaInfo.new(:version => opts[:assume])
+      si = SchemaInfo.first || SchemaInfo.new(:version => opts[:assume])
       if si.version < opts[:version]
         @migrations.sort_by { |m| m.version }.each do |k|
           k.migrate(:up) if si.version < k.version and k.version <= opts[:version]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ end
 require 'minitest/autorun'
 require 'rack/test'
 
-class TestCase < MiniTest::Unit::TestCase
+class TestCase < MiniTest::Test
   include Rack::Test::Methods
     
   def self.inherited(mod)


### PR DESCRIPTION
This fixes the ActiveRecord 4.0.0 warning about find(:first) being deprecated in favor of first, as well as the MiniTest warning about changed  class names.
