### PR TITLE
Use non-deprecated, secure HTTPS Rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :name => :camping
 
 if rack = ENV['RACK']


### PR DESCRIPTION
Otherwise warning appears:

> The source `:rubygems` is deprecated because HTTP requests are insecure.
