### PR TITLE
Two characters saved in #require

### DIFF
--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,4 +1,4 @@
-require "uri";require "rack";class Object;def meta_def m,&b;(class<<self;self
+require"uri";require"rack";class Object;def meta_def m,&b;(class<<self;self
 end).send:define_method,m,&b end end;module Camping;C=self;S=IO.read(__FILE__
 )rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.


### PR DESCRIPTION
This commit saves two spaces here:

``` ruby
require "uri";require "rack";
```

turning it into

``` ruby
require"uri";require"rack";
```
