### PR TITLE
improve summary and make it neutral

### DIFF
--- a/constants.rb
+++ b/constants.rb
@@ -16,7 +16,7 @@ def camping_spec
     s.has_rdoc = true
     s.extra_rdoc_files = FileList["README.md", "CHANGELOG", "COPYING", "book/*"].to_a
     s.rdoc_options += RDOC_OPTS + ['--exclude', '^(examples|extras)\/', '--exclude', 'lib/camping.rb']
-    s.summary = "minature rails for stay-at-home moms"
+    s.summary = "minature rails for everyone"
     s.author = "why the lucky stiff"
     s.email = 'why@ruby-lang.org'
     s.homepage = 'http://camping.rubyforge.org/'


### PR DESCRIPTION
I know I'm being a little arrogant by opening a pull request that changes the summary of the project I have not even contributed to yet, but bare with me, please. It's just a form of raising an issue with summary to your attention, feel free to reject it.

Anyways, I was suprised by the summary of this project because it implies that "even moms that stay at home can use it", which is, if you ask me, a sexist statement. Why not improve it and make it neutral?

It's a shame for such a great and underrated project to have such a poor summary.
