### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/book/01_introduction.md
+++ b/book/01_introduction.md
@@ -1,4 +1,4 @@
-#Introduction
+# Introduction
 
 Camping is a small web framework, less than 4k, a little white blood cell in
 the vein of Rails. This little book will start with a tutorial which takes

--- a/book/02_getting_started.md
+++ b/book/02_getting_started.md
@@ -1,4 +1,4 @@
-#Getting Started
+# Getting Started
 
 Start a new text file called nuts.rb. Here's what you put inside:
  
@@ -25,7 +25,7 @@ Your browser window should show:
 No problem with that. The Camping Server is running, but it doesn't know what
 to show. Let's tell him.
 
-##Hello clock
+## Hello clock
 
 So, you've got Camping installed and it's running. Keep it running. You can
 edit files and The Camping Server will reload automatically. When you need to
@@ -46,7 +46,7 @@ the time, e.g.
 
     Sun Jul 15 12:56:15 +0200 2007
 
-##Enjoying the view
+## Enjoying the view
 
 The Camping microframework allows us to separate our code using the MVC
 (Model-View-Controller) design pattern. Let's add a view to our Nuts
@@ -94,7 +94,7 @@ Soon enough, you'll find that you can return anything from the controller, and
 it will be sent to the browser. But let's keep that for later and start
 investigating the routes.
 
-##Routes
+## Routes
 
 You probably noticed the weird <tt>R '/'</tt> syntax in the previous page.
 This is an uncommon feature of Ruby that is used in our favorite
@@ -135,7 +135,7 @@ Add this to `nuts.rb` and try if you can hit all of the controllers.
 Also notice how everything inside a parenthesis gets passed into the method,
 and is ready at your disposal.
 
-###Simpler routes
+### Simpler routes
 
 This just in:
 
@@ -313,7 +313,7 @@ own pages.
   
 Now I have two pages: One about hiking and one about fishing.
 
-##Wrapping it up
+## Wrapping it up
 
 Wouldn't it be nice if we could show this wonderful our pages in a browser?
 Update nuts.rb so it also contains something like this:
@@ -386,7 +386,7 @@ There's a lot of improvements you could do here. Let me suggest:
 Helpers can work generating Markaby's code. You could write a helper for show
 some kind of data and call it from your views (Add a layout).
 
-##The last touch
+## The last touch
 
 We have one major flaw in our little application. You can't edit or add new
 pages. Let's see if we can fix that:
@@ -452,7 +452,7 @@ integrate all of this with what you already have.
     end
   
 
-##Phew.
+## Phew.
 
 You've taken quite a few steps in the last minutes. You deserve a break. But
 let's recap for a moment:

--- a/book/03_more_about_controllers.md
+++ b/book/03_more_about_controllers.md
@@ -17,7 +17,7 @@ But that is virtual, the site have not really a directory structure like that...
 That would be useless. The site use a "routes drawing system" for get a _control_
 of that routes and that is what *the controller* does.
 
-##Camping Routes and Controllers
+## Camping Routes and Controllers
 
 In camping, each `"capitalized"` word is like the slash. For example:
 
@@ -33,7 +33,7 @@ Or you could use instead the weird R for get more control in your routes
 
 All of this will be declared inside the Nuts::Controllers module
 
-##Controllers Parameters
+## Controllers Parameters
 
 Controllers can also handle your application's parameters. For example
 when the client ask four a route like /post/1 the static web server shall
@@ -68,7 +68,7 @@ The _X_ mean: -math anything, including number and words. It will math:
 But it will NOT math: /post/mypost/1 or anything that could have a slash.
 Because a "/" mean: "the next directory", and that is another Capitalized word.
 
-##Getting parameter from the controller
+## Getting parameter from the controller
 
 Ok, we have the controller that match parameters; and now what?
 

--- a/book/04_more_about_views.md
+++ b/book/04_more_about_views.md
@@ -9,7 +9,7 @@ that.
 The user only see their browser and our application is just and HTML document.
 
 
-##Camping Views
+## Camping Views
 
 Inside the Nut::Views module, we will write methods. That method shall called
 with the render sentence. The views do not use class.
@@ -59,7 +59,7 @@ Imagine your applications as a big building. The controller as the
 corridors and the views as the offices. Where are the offices and we do
 in each office?
 
-##Views and Controllers
+## Views and Controllers
 
 Model View and Controller, are joined but not scrambled. The views use
 R(ControllerName) for call the controllers and "move". The controller
@@ -90,7 +90,7 @@ will use "render" for call the view.
 No, we don't have it behind the curtains, but the user believe it. There
 is the view, enjoy the show.
 
-##Template engine
+## Template engine
 
 We spoke about the views, and HTML, but we are not using html's tags for
 our view...

--- a/book/05_more_about_markaby.md
+++ b/book/05_more_about_markaby.md
@@ -1,4 +1,4 @@
-##Where Markaby's come from
+## Where Markaby's come from
 
 A great musician, writer and programmer (and a bit crazy) named
 [_why](http://en.wikipedia.org/wiki/Why_the_lucky_stiff) wrote camping.  Before
@@ -32,7 +32,7 @@ That do not mean "html knowledge unneeded"
 
 But that is only the beginning, we can do more wild things.
 
-##Writing HTML pragmatically
+## Writing HTML pragmatically
 
 For example: if we want show a table for show users and their real
 names:
@@ -54,7 +54,7 @@ names:
 
 Take a look better [here](https://github.com/camping/mab/blob/master/README.md)
 
-##Markaby and the layout
+## Markaby and the layout
 
 There is a special view named "layout". The layout, is view that will be
 rendered each time any other view are rendered. In fact, the layout will take
@@ -134,7 +134,7 @@ head or title.
 Finally, it will be rendering a "p" named footer. That will be the footer in
 all our pages.
 
-##Tip
+## Tip
 
 What would happen? If you do this in the layout:
 

--- a/book/51_upgrading.md
+++ b/book/51_upgrading.md
@@ -5,8 +5,8 @@ applications. If you're looking for all the new features in a version, please
 have a look at the CHANGELOG in the Camping source.
 
 
-##From 2.0 to 2.1
-###Options
+## From 2.0 to 2.1
+### Options
 
 In Camping 2.1 there is now a built-in way to store options and settings. If
 you use cookie session, it means that you'll now have to change to:
@@ -17,8 +17,8 @@ you use cookie session, it means that you'll now have to change to:
     end
 
 
-##From 1.5 to 2.0
-###Rack
+## From 1.5 to 2.0
+### Rack
 
 The biggest change in 2.0 is that it now uses [Rack](http://rack.rubyforge.org/)
 internally. This means that you'll now have to deploy Camping differently, but
@@ -26,7 +26,7 @@ hopefully more easily too. Now every Camping application is also a Rack
 application, so simply check out the documentation to the server of your
 choice.
 
-###`require 'camping/db'`
+### `require 'camping/db'`
 
 In earlier versions of Camping, you loaded database support by:
 
@@ -61,7 +61,7 @@ We also encourage you to use <tt>Model.table_name</tt> instead of
       end
     end
 
-###Cookie Sessions
+### Cookie Sessions
 
 Camping 2.0 now uses a cookie-based session system, which means you now longer
 need a database in order to use sessions. The disadvantage of this is that
@@ -81,7 +81,7 @@ required, and see Camping::Session more details.
       # Camping::Models::Session.create_schema
     end
   
-###Error handling
+### Error handling
 
 Camping now uses three methods in order to handle errors. These replaces the
 old classes NotFound and ServerError.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
