### PR TITLE
Add routes helper. You can now mount multiple apps again.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,16 @@
+= 2.3
+===
+* New routes command line helper command.
+* plugin support added via the gear method.
+* Restored support for mounting multiple apps.
+* Add url_prefix option for mounting apps at different urls.
+* Increase camping test limit to 5120 bytes. We needed just a bit more space.
+* Add a book stub about Models.
+* Add a chapter about middleware and how it works.
+* Camping a '/' is now forcibly terminating each route. May revert this back if we run into trouble.
+
 = 2.2
-=== date not yet determined
+=== Never Released
 * Updated ActiveRecord migrations class to reference version 6.1
 * Removed deprecated gemfile definitions
 * Rename deprecated methods

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 
 group :test do
   gem 'minitest', '~> 5.0'
+  gem 'minitest-reporters'
   gem 'rack-test'
   gem 'ruby_parser'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -118,6 +118,8 @@ namespace :check do
     unless u == m
       STDERR.puts "camping.rb and camping-unabridged.rb are not synchronized."
       error = true
+    else
+      puts "✅ synchronized....."
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -123,7 +123,7 @@ namespace :check do
     end
   end
 
-  SIZE_LIMIT = 4096
+  SIZE_LIMIT = 5120
   desc "Compare camping sizes to unabridged"
   task :size do
     FileList["lib/camping*.rb"].each do |path|

--- a/bin/camping
+++ b/bin/camping
@@ -3,6 +3,7 @@
 $:.unshift File.dirname(__FILE__) + "/../lib"
 
 require 'camping'
+# require 'camping-unabridged' # comment out the above line and uncomment this line to run camping unabridged with all sorts of stuff in it.
 require 'camping/server'
 
 begin

--- a/book/06_more_about_models.md
+++ b/book/06_more_about_models.md
@@ -1,0 +1,58 @@
+## More about Models
+
+Models are used to persist data. That data could be anything. The balance in a bank account, A list of your favorite restaurants, your blog posts, you name it. Camping uses the *ActiveRecord* Gem, an ORM (object-relational mapper), that maps Database tables to objects.
+
+We define models by inheriting from a base model named Base:
+
+```ruby
+class User < Base end
+```
+
+Very creative. Base is really just an alias for ActiveRecord, nothing fancy. We put our models into a namespaced module named after our App:
+
+```ruby
+Camping.goes :Nuts
+
+module Nuts::Models
+    class User < Base end
+end
+```
+
+Remember from earlier that Models need to be defined before our controllers, otherwise we can't use em. So keep them close to the top.
+
+The new User model we've defined has a small problem, it's completely empty, it doesn't have any data that can be stored in it. Camping models map Database tables to objects automatically, but this model doesn't have a database table yet. To fix that we'll create a migration:
+
+```ruby
+Camping.goes :Nuts
+
+module Nuts::Models
+    class User < Base; end
+
+    # Define a migration to add users
+    class AddUser < V 1.2
+        def self.up
+            create_table User.table_name do |t|
+                t.string :username
+                t.string :email
+                t.timestamps
+            end
+        end
+
+        def self.down
+            drop_table User.table_name
+        end
+    end
+end
+```
+
+Databases, like birds, migrate. Migrations move our database from one configuration to another. In our case we're adding users. So cool. User's should be able to log in, sign up, maybe make some pages. We could make the next myspace. To get our database to make a users table we need force our app to create the schema.
+
+```ruby
+def Nuts.create
+    Nuts::Models.create_schema
+end
+```
+
+Now that puppy will migrate when we launch our app.
+
+Our Users now have greater hope to survive. So great. I love it.

--- a/book/06_rules_of_thumb.md
+++ b/book/06_rules_of_thumb.md
@@ -82,10 +82,27 @@ end
 
 Rather than building huge Camping apps, the idea here is to write small apps which can each be mounted at directories on your web server. One restriction: these apps will share a database. However, this allows applications to access each other’s tables and simplifies setup and configuration.
 
-The camping tool starts a web server which mounts apps in this fashion. If you want to mount all your apps, run camping apps/**/*.rb.
+To mount multiple camping apps, you can `require` the app files. When you mount more than one app they won't be mounted according to their parent directory, routing is explicit. If you'd like to give one of your apps a prefix, set the `url_prefix` option in your app:
+
+```ruby
+# camp.rb
+require 'camping'
+Camping.goes :Blog
+require 'blog.rb'
+
+Camping.goes :Wiki
+require 'wiki.rb'
+Wiki.set :url_prefix, 'tepee/'
+
+Camping.goes :Charty
+require 'charty.rb'
+Charty.set :url_prefix, 'charts/'
+
+```
+
+By default Camping will look for a file called `camp.rb` in the root where Camping is executed. You can also supply a ruby filename to load your apps from there.
 
 You’ll end up with:
-
 ```
 http://localhost:3301/blog, a blogging app.
 http://localhost:3301/tepee, a wiki app.
@@ -114,6 +131,7 @@ The Camping Server is basically a set of rules. At the very least, The Camping S
 - Load all Camping apps in a directory.
 - Load new apps that appear in that directory.
 - Mount those apps according to their filename. (e.g. blog.rb is mounted at /blog.)
+
 - Run each app’s create method upon startup.
 - Reload the app if its modification time changes.
 - Reload the app if it requires any files under the same directory and one of their modification times changes.

--- a/book/10_middleware.md
+++ b/book/10_middleware.md
@@ -1,0 +1,28 @@
+Middleware in Camping is just Rack Middleware, and if you're familiar with Rack middleware then you'll be right at home. I'm going to assume that you have no idea what Rack or Rack middleware *is*, Let's learn about it.
+
+# The HTTP Request
+
+The web works in a request -> response pattern. When we *GO* to a webpage our browser is making a *request* to a web server. That request is processed and a *response* is sent. We have already covered how a response is mapped to our ruby code through controllers in Chapter 3. Those responses could be any of a number of things, HTML, an image, JSON, CSS, Web servers are pretty capable. When using Camping you'll generally respond with HTML, CSS, or Javascript, maybe some images.
+
+As that request passes through your application you may need to make some decisions about it. Does the request try to get something with restricted access? Is it a request to a dynamic or cached file? Whatever it is we can write some Ruby code to make some decisions about that request before passing it along to Camping's router. That's what Middleware is for.
+
+Middleware is Rack based and follows Rack Middleware conventions. Write a class, name it whatever you want but it must have an `#initialize` and a `#call` method.
+
+```ruby
+class MyMiddleware
+  def initialize(app)
+    @app = app
+  end
+  def call(env)
+    status, headers, body = @app.call(env)
+    [status, headers, body]
+  end
+end
+```
+
+The `#initialize` method must store a reference to an `app` object that is passed in as a parameter. The `#call` method accepts an environment parameter that we call `env` and returns an array with 3 values: `status`, `headers`, and `body`. Now, when I first saw this I was confused, why do we immediately Call
+
+
+### notes:
+* really good railscast about it that's like... 13 years old: http://railscasts.com/episodes/151-rack-middleware?autoplay=true
+* An extremely old article about it: https://web.archive.org/web/20150105094611/https://www.amberbit.com/blog/2011/07/13/introduction-to-rack-middleware/

--- a/book/11_gear.md
+++ b/book/11_gear.md
@@ -1,0 +1,50 @@
+# Pack Your Gear
+Camping provides a way to include and expand Camping without messing with it's innards too much, we call these plugins gear.
+
+To use gear you need to *pack* it into camping:
+
+```ruby
+Camping.goes :Blog
+
+module Blog
+  pack Camping::Gear::CSRF
+end
+
+# or
+
+Blog.pack Camping::Gear::CSRF
+```
+
+Define your gear by opening a module:
+```ruby
+module Royalty
+  def queens
+    @queens ||= [ "Beyonce", "Niki", "Doja"]
+  end
+end
+```
+
+Gear define methods and helpers that are included in your app. Define a `ClassMethods` module to have class methods included:
+```ruby
+module Royalty
+  module ClassMethods
+    def secret_sauce
+      @_secret_sauce ||= SecureRandom.base64(32)
+    end
+  end
+  # /...
+end
+```
+
+You can also supply a setup callback method that runs after your gear is packed:
+```ruby
+module Royalty
+  # Run a setup routine with this Gear.
+  def self.setup(app)
+    @app = app
+    @app.set :saucy_secret, "top_secret_sauce"
+  end
+end
+```
+
+We'll be adding some really great gear soon. In the meantime, try making your own gear.

--- a/constants.rb
+++ b/constants.rb
@@ -1,7 +1,7 @@
 require 'rake'
 
 NAME = "camping"
-BRANCH = "2.2"
+BRANCH = "2.3"
 GIT = ENV['GIT'] || "git"
 REV = `#{GIT} rev-list HEAD`.strip.split.length
 VERS = ENV['VERSION'] || (REV.zero? ? BRANCH : [BRANCH, REV] * '.')

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -49,11 +49,12 @@ end
 module Camping
   C = self
   S = IO.read(__FILE__) rescue nil
-  P = "<h1>Camping Problem!</h1><h2>%s</h2>"
+  P = "<h1>Cam\ping Problem!</h1><h2>%s</h2>"
   U = Rack::Utils
   O = {} # Our Hash of Options
   Apps = [] # Our array of Apps
   SK = :camping #Key for r.session
+
   # An object-like Hash.
   # All Camping query string and cookie variables are loaded as this.
   #
@@ -453,7 +454,6 @@ module Camping
     end
   end
 
-
   # Controllers receive the requests and send a response back to the client.
   # A controller is simply a class which must implement the HTTP methods it
   # wants to accept:
@@ -624,17 +624,18 @@ module Camping
 
   class << self
 
-    # Helper method for getting routes from the controllers
+    # Helper method for getting routes from the controllers.
+    # helps Camping::Server map routes to multiple apps.
     # Usage:
     #
     #   Nuts.routes
     #   Camping.routes
     #   Nuts.routes
     #
-    # def routes # I think we'll remove this as it's kinda weak, and supplanted by a better command line solution.
-    #   X.M
-    #   (Apps.map(&:routes)<<X.v).flatten
-    # end
+    def routes
+      X.M
+      (Apps.map(&:routes)<<X.v).flatten
+    end
 
     # Ruby web servers use this method to enter the Camping realm. The +e+
     # argument is the environment variables hash as per the Rack specification.
@@ -687,7 +688,6 @@ module Camping
       d(:call) { |e| m.call(e) }
     end
 
-
     # Add gear to your app:
     #
     #   module Blog
@@ -703,20 +703,22 @@ module Camping
     # Sometimes you might have ClassMethods that you want to modify camping with,
     # This gives us a way to do that.
     #
-    # The only requirement for a plugin is to have a setup method and a ClassMethods module:
+    # Optionally a plugin may have a setup method and a ClassMethods module:
     #
     #   module MyGear
-    #     def self.setup;end
-    #     module ClassMethods;end
+    #     def self.setup
+    #       # Perform setup actions
+    #     end
+    #     module ClassMethods
+    #       # Define Class Methods here
+    #     end
     #   end
     #
     def gear(g)
       include g
-      extend g::ClassMethods
-      g.setup(self)
+      extend g::ClassMethods if defined?(g::ClassMethods)
+      g.setup(self) if g.respond_to?(:setup)
     end
-
-
 
     # A hash where you can set different settings.
     def options
@@ -839,5 +841,6 @@ module Camping
 
   autoload :Mab, 'camping/mab'
   autoload :Template, 'camping/template'
+
   C
 end

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -719,7 +719,7 @@ module Camping
     # Optionally a plugin may have a setup method and a ClassMethods module:
     #
     #   module MyGear
-    #     def self.setup
+    #     def self.setup(s)
     #       # Perform setup actions
     #     end
     #     module ClassMethods

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -704,7 +704,7 @@ module Camping
     # Add gear to your app:
     #
     #   module Blog
-    #     gear Camping::Gear::CSRF
+    #     pack Camping::Gear::CSRF
     #   end
     #
     # This feature is an experiment. Inspired by the way that Cuba allows
@@ -727,7 +727,7 @@ module Camping
     #     end
     #   end
     #
-    def gear(g)
+    def pack(g)
       include g
       extend g::ClassMethods if defined?(g::ClassMethods)
       g.setup(self) if g.respond_to?(:setup)

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -17,10 +17,10 @@ E ||= "Content-Type"
 Z ||= "text/html"
 
 class Object #:nodoc:
-  # meta_def, used to define a method onto an object's class.
-  def md(m,&b) #:nodoc:
+  def meta_def(m,&b) #:nodoc:
     (class<<self;self end).send(:define_method,m,&b)
   end
+  alias d meta_def
 end
 
 # If you're new to Camping, you should probably start by reading the first
@@ -559,8 +559,8 @@ module Camping
       def R *u
         r=@r
         Class.new {
-          md(:urls){u}
-          md(:inherited){|x|r<<x}
+          d(:urls){u}
+          d(:inherited){|x|r<<x}
         }
       end
 
@@ -612,7 +612,7 @@ module Camping
           k = const_get(c)
           k.send :include,C,X,Base,Helpers,Models
           @r=[k]+@r if @r-[k]==@r
-          k.md(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&N.method(:[]))*'/'}"]}if !k.respond_to?:urls
+          k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&N.method(:[]))*'/'}"]}if !k.respond_to?:urls
         }
       end
     end
@@ -684,7 +684,7 @@ module Camping
     #   end
     def use(*a, &b)
       m = a.shift.new(method(:call), *a, &b)
-      md(:call) { |e| m.call(e) }
+      d(:call) { |e| m.call(e) }
     end
 
 

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -607,8 +607,8 @@ module Camping
       # Don't call it too early though - any controllers added after this
       # method was called won't work properly.
       def M
-        # def M #:nodoc:
-        # end
+        def M #:nodoc:
+        end
         constants.map { |c|
           k = const_get(c)
           k.send :include,C,X,Base,Helpers,Models

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -53,6 +53,7 @@ module Camping
   O = { url_prefix: "" } # Our Hash of Options
   Apps = [] # Our array of Apps
   SK = :camping #Key for r.session
+  G = [] # Our array of Gear
 
   # An object-like Hash.
   # All Camping query string and cookie variables are loaded as this.
@@ -728,9 +729,15 @@ module Camping
     #   end
     #
     def pack(g)
+      G << g
       include g
       extend g::ClassMethods if defined?(g::ClassMethods)
       g.setup(self) if g.respond_to?(:setup)
+    end
+
+    # Helper method to list gear
+    def gear
+      G
     end
 
     # A hash where you can set different settings.

--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -542,6 +542,7 @@ module Camping
   module Controllers
     @r = []
     class << self
+
       # Add routes to a controller class by piling them into the R method.
       #
       # The route is a regexp which will match the request path. Anything
@@ -606,8 +607,8 @@ module Camping
       # Don't call it too early though - any controllers added after this
       # method was called won't work properly.
       def M
-        def M #:nodoc:
-        end
+        # def M #:nodoc:
+        # end
         constants.map { |c|
           k = const_get(c)
           k.send :include,C,X,Base,Helpers,Models

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,7 +1,7 @@
 require"uri";require"rack";E||="Content-Type";Z||="text/html"
 class Object;def meta_def m,&b;(class<<self;self
-end).send:define_method,m,&b end;alias d meta_def;end;module Camping;C=self;S=IO.read(__FILE__
-)rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
+end).send:define_method,m,&b end;end;module Camping;C=self;S=IO.read(__FILE__
+)rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={url_prefix:""};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
 to_s]:super end;undef id,type if ??==63 end;class Cookies<H;attr_accessor :_p;
 def _n;@n||={}end;alias _s []=;def set k,v,o={};_s(j=k.to_s,v);_n[j]=
@@ -33,22 +33,24 @@ H[r.session[SK]||{}],{E=>Z},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=
 n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self
 end end;module Controllers;@r=[];class<<self;def R *u;r=@r;Class.
-new{d(:urls){u};d(:inherited){|x|r<<x}}end;
+new{meta_def(:urls){u};meta_def(:inherited){|x|r<<x}}end;
 def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
-[I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
-merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
+[I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;
+module F;T= ->(u){return u unless u.respond_to? :last;u << "/" unless u.last == "/";u};
+A= ->(c,u,p){u.prepend("/"+p) unless c.to_s == "I"}end;N=H.new{|_,x|x.downcase}.
+merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M(pr);def M(pr);end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
-@r=[k]+@r if @r-[k]==@r;k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
-N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=
-Controllers;class<<self;def routes;X.M;(Apps.map(&:routes)<<X.v).flatten;end;
-def call e;X.M;k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
+@r=[k]+@r if @r-[k]==@r;k.meta_def(:urls){[F::T.(F::A.(k,"#{c.to_s.scan(/.[^A-Z]*/)
+.map(&N.method(:[]))*'/'}",pr))]}if !k.respond_to?:urls}end end;I=R()end;X=
+Controllers;class<<self;def routes;X.M O[:url_prefix];(Apps.map(&:routes)<<X.v).flatten;end;
+def call e;X.M O[:url_prefix];k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
 downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
-def method_missing m,c,*a;X.M;h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
+def method_missing m,c,*a;X.M O[:url_prefix];h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-d(:call){|e|m.call(e)}end;def gear g;include g;
+meta_def(:call){|e|m.call(e)}end;def gear g;include g;
 extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self)if g.respond_to?(:setup)end;
 def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -38,7 +38,7 @@ def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
-merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
+merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
 @r=[k]+@r if @r-[k]==@r;k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -38,7 +38,7 @@ def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
-merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;constants.
+merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
 @r=[k]+@r if @r-[k]==@r;k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,7 +1,7 @@
 require"uri";require"rack";E||="Content-Type";Z||="text/html"
 class Object;def meta_def m,&b;(class<<self;self
 end).send:define_method,m,&b end;alias d meta_def;end;module Camping;C=self;S=IO.read(__FILE__
-)rescue nil;P="<h1>Camping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
+)rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
 to_s]:super end;undef id,type if ??==63 end;class Cookies<H;attr_accessor :_p;
 def _n;@n||={}end;alias _s []=;def set k,v,o={};_s(j=k.to_s,v);_n[j]=
@@ -42,13 +42,15 @@ merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
 @r=[k]+@r if @r-[k]==@r;k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=
-Controllers;class<<self;def call e;X.M;k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
+Controllers;class<<self;def routes;X.M;(Apps.map(&:routes)<<X.v).flatten;end;
+def call e;X.M;k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
 downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M;h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-d(:call){|e|m.call(e)}end;def gear g;include g;extend g::ClassMethods;
-g.setup(self)end;def options;O end;def set k,v;O[k]=v end
+d(:call){|e|m.call(e)}end;def gear g;include g;
+extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self)if g.respond_to?(:setup)end;
+def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
 a.set :_t,H[*b||[]];end;end

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,7 +1,7 @@
-require"uri";require"rack";E="Content-Type";Z="text/html"
-class Object;def meta_def m,&b;(class<<self;self
+require"uri";require"rack";E||="Content-Type";Z||="text/html"
+class Object;def md m,&b;(class<<self;self
 end).send:define_method,m,&b end end;module Camping;C=self;S=IO.read(__FILE__
-)rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
+)rescue nil;P="<h1>Camping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
 to_s]:super end;undef id,type if ??==63 end;class Cookies<H;attr_accessor :_p;
 def _n;@n||={}end;alias _s []=;def set k,v,o={};_s(j=k.to_s,v);_n[j]=
@@ -33,25 +33,25 @@ H[r.session[SK]||{}],{E=>Z},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=
 n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self
 end end;module Controllers;@r=[];class<<self;def R *u;r=@r;Class.
-new{meta_def(:urls){u};meta_def(:inherited){|x|r<<x}}end;
+new{md(:urls){u};md(:inherited){|x|r<<x}}end;
 def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
 merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
-@r=[k]+@r if @r-[k]==@r;k.meta_def(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
+@r=[k]+@r if @r-[k]==@r;k.md(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=
-Controllers;class<<self;def routes;X.M;(Apps.map(&:routes)<<X.v).flatten;end;def
-goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
-IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
-a.set :_t,H[*b||[]];end;def call e;X.M
-k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
+Controllers;class<<self;def call e;X.M;k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
 downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M;h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-meta_def(:call){|e|m.call(e)}end;def options;O end;def set k,v;O[k]=v end end
+md(:call){|e|m.call(e)}end;def gear g;include g;extend g::ClassMethods;
+g.setup(self)end;def options;O end;def set k,v;O[k]=v end
+def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
+IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
+a.set :_t,H[*b||[]];end;end
 module Views;include X,Helpers end;module Models;autoload:Base,'camping/ar'
 Helpers.send:include,X,self end;autoload:Mab,'camping/mab'
 autoload:Template,'camping/template';C end

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,6 +1,6 @@
 require"uri";require"rack";E||="Content-Type";Z||="text/html"
-class Object;def md m,&b;(class<<self;self
-end).send:define_method,m,&b end end;module Camping;C=self;S=IO.read(__FILE__
+class Object;def meta_def m,&b;(class<<self;self
+end).send:define_method,m,&b end;alias d meta_def;end;module Camping;C=self;S=IO.read(__FILE__
 )rescue nil;P="<h1>Camping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
 to_s]:super end;undef id,type if ??==63 end;class Cookies<H;attr_accessor :_p;
@@ -33,21 +33,21 @@ H[r.session[SK]||{}],{E=>Z},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=
 n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self
 end end;module Controllers;@r=[];class<<self;def R *u;r=@r;Class.
-new{md(:urls){u};md(:inherited){|x|r<<x}}end;
+new{d(:urls){u};d(:inherited){|x|r<<x}}end;
 def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
 merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
-@r=[k]+@r if @r-[k]==@r;k.md(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
+@r=[k]+@r if @r-[k]==@r;k.d(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=
 Controllers;class<<self;def call e;X.M;k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
 downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M;h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-md(:call){|e|m.call(e)}end;def gear g;include g;extend g::ClassMethods;
+d(:call){|e|m.call(e)}end;def gear g;include g;extend g::ClassMethods;
 g.setup(self)end;def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,4 +1,5 @@
-require"uri";require"rack";class Object;def meta_def m,&b;(class<<self;self
+require"uri";require"rack";E="Content-Type";Z="text/html"
+class Object;def meta_def m,&b;(class<<self;self
 end).send:define_method,m,&b end end;module Camping;C=self;S=IO.read(__FILE__
 )rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={};Apps=[];
 SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
@@ -23,16 +24,17 @@ end;end;def mab &b;extend(Mab);mab(&b) end;def r s,b,h={};b,h=
 h,b if Hash===b;@status=s;@headers.merge!(h);@body=b end;def redirect *a;r 302,
 '','Location'=>URL(*a).to_s end;def r404 p;P%"#{p} not found"end;def r500 k,m,e
 raise e end;def r501 m;P%"#{m.upcase} not implemented"end;def serve(p,c)
-(t=Rack::Mime.mime_type p[/\..*$/],"text/html")&&@headers["Content-Type"]=t;c;end;def to_a;@env[
+(t=Rack::Mime.mime_type p[/\..*$/],Z)&&@headers[E]=t;c;end;def to_a;@env[
 'rack.session'][SK]=Hash[@state];r=Rack::Response.new(@body,@status,@headers)
 @cookies._n.each{|k,v|r.set_cookie k,v};r.to_a end;def initialize env,m
 r=@request=Rack:: Request.new(@env=env);@root,@input,@cookies,@state,@headers,
 @status,@method=r.script_name.sub(/\/$/,''),n(r.params),Cookies[r.cookies],
-H[r.session[SK]||{}],{'Content-Type'=>'text/html'},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
+H[r.session[SK]||{}],{E=>Z},m=~/r(\d+)/?$1.to_i: 200,m;@cookies._p=self/"/" end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=
 n(v);m}: h end;def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self
 end end;module Controllers;@r=[];class<<self;def R *u;r=@r;Class.
-new{meta_def(:urls){u};meta_def(:inherited){|x|r<<x}}end;def D p,m,e;p='/'if
+new{meta_def(:urls){u};meta_def(:inherited){|x|r<<x}}end;
+def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;N=H.new{|_,x|x.downcase}.
@@ -40,7 +42,7 @@ merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M;def M;end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
 @r=[k]+@r if @r-[k]==@r;k.meta_def(:urls){["/#{c.to_s.scan(/.[^A-Z]*/).map(&
 N.method(:[]))*'/'}"]}if !k.respond_to?:urls}end end;I=R()end;X=
-Controllers;class<<self;def
+Controllers;class<<self;def routes;X.M;(Apps.map(&:routes)<<X.v).flatten;end;def
 goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
 a.set :_t,H[*b||[]];end;def call e;X.M

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -50,7 +50,7 @@ downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M O[:url_prefix];h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-meta_def(:call){|e|m.call(e)}end;def gear g;include g;
+meta_def(:call){|e|m.call(e)}end;def pack g;include g;
 extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self)if g.respond_to?(:setup)end;
 def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -2,7 +2,7 @@ require"uri";require"rack";E||="Content-Type";Z||="text/html"
 class Object;def meta_def m,&b;(class<<self;self
 end).send:define_method,m,&b end;end;module Camping;C=self;S=IO.read(__FILE__
 )rescue nil;P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;O={url_prefix:""};Apps=[];
-SK=:camping;class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
+SK=:camping;G=[];class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m.
 to_s]:super end;undef id,type if ??==63 end;class Cookies<H;attr_accessor :_p;
 def _n;@n||={}end;alias _s []=;def set k,v,o={};_s(j=k.to_s,v);_n[j]=
 {:value=>v,:path=>_p}.update o;end;def []=(k,v)set(k,v,v.is_a?(Hash)?v:{})end
@@ -50,9 +50,9 @@ downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M O[:url_prefix];h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-meta_def(:call){|e|m.call(e)}end;def pack g;include g;
+meta_def(:call){|e|m.call(e)}end;def pack g;G<<g;include g;
 extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self)if g.respond_to?(:setup)end;
-def options;O end;def set k,v;O[k]=v end
+def gear;G end;def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
 a.set :_t,H[*b||[]];end;end

--- a/lib/camping/ar.rb
+++ b/lib/camping/ar.rb
@@ -84,7 +84,7 @@ module Camping
     module_eval $AR_EXTRAS
   end
 end
-Camping::S.sub! /autoload\s*:Base\s*,\s*['"]camping\/ar['"]/, $AR_EXTRAS
+Camping::S.sub!(/autoload\s*:Base\s*,\s*['"]camping\/ar['"]/, $AR_EXTRAS)
 Camping::Apps.each do |c|
   c::Models.module_eval $AR_EXTRAS.gsub('Camping', c.to_s)
 end

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -1,167 +1,115 @@
 module Camping
   module CommandsHelpers
-    class RoutesParser
 
-      def self.parse(app, silent)
-        new(app).parse silent
-      end
-
-      def initialize(app)
-        @parent_app, @routes = app, []
-      end
-
-      def url_from_name(controller_name, params)
-
-        # We have to figure out the route from the Controller name
-        splitty = controller_name.split(/(?<=\p{Ll})(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/)
-        url, it = "", 0
-        splitty.each { |sis|
-          if sis != "X" && sis != "N"
-            url += "/#{sis.downcase}"
-          else
-            if params[it] == nil
-              if sis == "N"
-                url += "/:Integer"
-              elsif sis == "X"
-                url += "/:String"
-              else
-                url += "/#{sis}"
-              end
-            else
-              url += "/:#{params[it]}"
-            end
-            it += 1
-          end
-        }
-        url
-      end
-
-      def makeRoutes(controllers, controller, prefix = "", appname = "", routes = nil)
-        contr_const, mappedURLS = controllers.const_get(controller), []
-
-        (contr_const.instance_methods false).each { |http_method|
-
-          # Parse named parameters from the method names
-          params = contr_const.instance_method(http_method).parameters.map(&:last).map(&:to_s)
-
-          if routes == nil
-            url = url_from_name(controller.name, params)
-            url = prefix + url if !prefix.empty?
-            # puts "#{http_method.upcase} - prefix: #{prefix}, url: #{url}"
-            mappedURLS.append Route.new(http_method, controller.name, appname, url)
-          else
-            # We have a list of routes that we need to match to methods now.
-            routes.each { |route|
-              url = url_from_name(controller.name, params)
-              url = prefix + route if !prefix.empty?
-              # puts "#{http_method.upcase} - prefix: #{prefix}, url: #{url}"
-              mappedURLS.append Route.new(http_method, controller.name, appname, url)
-            }
-          end
-        }
-        mappedURLS
-      end
-
-      # Route Struct, for making and formatting a route.
-      Route = Struct.new(:http_method, :controller, :app, :url)
-      class Route
-
-        def to_s
-          "#{controller} #{normy(http_method)} " + "#{url}"
-        end
-
-        # pad the controller name to be the right length, if we can.
-        def padded_message(appNameWidth, width)
-          "#{"".ljust(appNameWidth, " ")}#{controller.ljust(width, " ")} #{normy(http_method)} " + "#{url}"
-        end
-
-        protected
-
-        def normy(themethod)
-          case themethod.to_s
-          when "post"
-            "POST    "
-          when "put"
-            "PUT     "
-          when "patch"
-            "PATCH   "
-          when "delete"
-            "DELETE  "
-          else
-            "GET     "
-          end
-        end
-
-      end
-
-      def parse(silent)
-        it = 0; routes = []; apps = []
-
-        if @parent_app.name == "Camping"
-          apps = @parent_app::Apps
-        else
-          apps.append @parent_app
-        end
-
-        # Iterate over each app
-        apps.each { |app|
-
-          prefix = ""; prefix = "/#{app.name.downcase}" unless it == 0
-          appname = app.name.downcase
-
-          #Iterate over each controller
-          app::X.constants.each { |controller|
-
-            contr_const = app::X.const_get(controller)
-
-            if (contr_const.respond_to? :urls) && !(contr_const.send :urls).empty?
-              urls = contr_const.send :urls
-              routes << makeRoutes(app::X, controller, prefix, appname, urls)
-            else
-              routes << makeRoutes(app::X, controller, prefix, appname)
-            end
-          }
-
-          it += 1
-        }
-
-        routes.flatten!
-
-        appNameWidth, width, appNames = 0, 0, []
+    RouteCollection = Struct.new(:routes)
+    class RouteCollection
+      # Displays formatted routes from a route collection
+      # Assumes that Route structs are stored in :routes.
+      def display
+        current_app, current_method = "", ""
         routes.each { |r|
-          width = r.controller.length + 3 if r.controller.length > width
-          appNameWidth = r.app.length + 3 if r.app.length > appNameWidth
+          # puts r
+          if current_app != r.app.to_s
+            puts ""
+            current_app = r.app.to_s
+            current_method = ""
+            puts r.app_header
+            puts "-----------------------------------"
+          end
+          if current_method != r.http_method.to_s
+            current_method = r.http_method.to_s
+            puts r.padded_message true
+          else
+            puts r.padded_message
+          end
         }
-        if silent != true
-          puts "#{"App".ljust(appNameWidth, " ")}#{"Controller".ljust(width, " ")} VERB     Route"
-          routes.each {|r|
-            if !appNames.include? r.app
-              puts "--------------------------------------"
-              puts "#{r.app.ljust(appNameWidth, " ")}".capitalize
-              appNames << r.app
-            end
-            puts r.padded_message(appNameWidth, width)
-          }
-        end
-        routes
-      end
-
-      # takes a route string, which is regex and converts it to the defined Class in the App.
-      def reverse_regex(pattern)
-        nstr = "(\d+)"
-        xstr = "([^/]+)"
-
-        if pattern == "/"
-          "Index"
-        else
-          newpattern = ""
-          (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
-          newpattern
-        end
-
       end
 
     end
+
+    # Route Struct, for making and formatting a route.
+    Route = Struct.new(:http_method, :controller, :app, :url)
+    class Route
+
+      def to_s
+        "#{http_method}: #{url}"
+      end
+
+      # pad the controller name to be the right length, if we can.
+      def padded_message(with_method = false)
+        with_method ? "#{http_method.to_s.upcase.ljust(10, " ") } " + "#{url}" : "           " + "#{url}"
+      end
+
+      def app_header
+        "#{app.to_s}"
+      end
+
+      def controller_header
+        "           #{app.to_s}::#{controller.to_s}"
+      end
+
+      protected
+
+      def http_methods
+        ["get", "post", "put", "patch", "delete"]
+      end
+
+    end
+
+    class RoutesParser
+      def self.parse(app)
+        new(app).parse
+      end
+
+      def initialize(app = Camping)
+        @parent_app, @routes = app, []
+      end
+
+      def parse
+        @parent_app.routes
+        collected_routes = []
+
+        make_routes =  -> (a) {
+          a::X.constants.map { |c|
+            k = a::X.const_get(c)
+            im = k.instance_methods(false).map!(&:to_s)
+            methods = im & ["get", "post", "put", "patch", "delete"]
+            if k.respond_to?:urls
+              methods.each { |m|
+                k.urls.each { |u|
+                  collected_routes.append Camping::CommandsHelpers::Route.new(m,c,a.to_s,u)
+                }
+              }
+            end
+          }
+        }
+
+        if @parent_app == Camping
+          @parent_app::Apps.each {|a|
+            make_routes.(a)
+          }
+        else
+          make_routes.(@parent_app)
+        end
+
+        routes_collection = Camping::CommandsHelpers::RouteCollection.new(collected_routes)
+      end
+    end
+
+#       # takes a route string, which is regex and converts it to the defined Class in the App.
+#       def reverse_regex(pattern)
+#         nstr = "(\d+)"
+#         xstr = "([^/]+)"
+#
+#         if pattern == "/"
+#           "Index"
+#         else
+#           newpattern = ""
+#           (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
+#           newpattern
+#         end
+#
+#       end
 
   end
 
@@ -169,7 +117,9 @@ module Camping
 
     # A helper method to spit out Routes for an application
     def self.routes(theApp = Camping, silent = false)
-      Camping::CommandsHelpers::RoutesParser.parse theApp, silent
+      routes = Camping::CommandsHelpers::RoutesParser.parse theApp
+      routes.display unless silent == true
+      return routes
     end
 
   end

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -14,7 +14,6 @@ module Camping
 
         # We have to figure out the route from the Controller name
         splitty = controller_name.split(/(?<=\p{Ll})(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/)
-
         url, it = "", 0
         splitty.each { |sis|
           if sis != "X" && sis != "N"
@@ -51,10 +50,9 @@ module Camping
             # puts "#{http_method.upcase} - prefix: #{prefix}, url: #{url}"
             mappedURLS.append Route.new(http_method, controller.name, appname, url)
           else
-
             # We have a list of routes that we need to match to methods now.
             routes.each { |route|
-              url = route
+              url = url_from_name(controller.name, params)
               url = prefix + route if !prefix.empty?
               # puts "#{http_method.upcase} - prefix: #{prefix}, url: #{url}"
               mappedURLS.append Route.new(http_method, controller.name, appname, url)
@@ -134,7 +132,7 @@ module Camping
           width = r.controller.length + 3 if r.controller.length > width
           appNameWidth = r.app.length + 3 if r.app.length > appNameWidth
         }
-        if silent != false
+        if silent != true
           puts "#{"App".ljust(appNameWidth, " ")}#{"Controller".ljust(width, " ")} VERB     Route"
           routes.each {|r|
             if !appNames.include? r.app
@@ -157,7 +155,7 @@ module Camping
           "Index"
         else
           newpattern = ""
-          (pattern.gsub(xstr, "X").gsub(nstr, "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
+          (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
           newpattern
         end
 

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -1,8 +1,197 @@
 module Camping
-  class Commands
-    def initialize(*args)
-      puts "Parsing Commands"
-      puts args
+  module CommandsHelpers
+    class RoutesParser
+
+      def self.parse(app)
+        new(app).parse
+      end
+
+      def initialize(app)
+        @parent_app = app
+        @routes = []
+      end
+
+      def normy(themethod)
+        case themethod.to_s
+        when "post"
+          "POST  "
+        when "put"
+          "PUT   "
+        when "patch"
+          "PATCH "
+        when "delete"
+          "DELETE"
+        else
+          "GET   "
+        end
+      end
+
+      def makeRoutes(controllers, controller)
+
+        contr_const = controllers.const_get(controller)
+
+        # gets the http methods from the list of instance methods
+        http_methods = contr_const.instance_methods false
+        class_methods = contr_const.methods false
+
+        mappedURLS = []
+
+        http_methods.each { |http_method|
+          # Gets the list of params
+          named_parameters = contr_const.instance_method(http_method).parameters.map(&:last).map(&:to_s)
+
+          # Craft the URL
+          splitty = controller.name.split(/(?<=\p{Ll})(?=\p{Lu})|(?<=\p{Lu})(?=\p{Lu}\p{Ll})/)
+
+          mappedurl = ""; parameteriteration = 0
+          splitty.each { |sis|
+            if sis != "X" && sis != "N"
+              mappedurl += "/#{sis.downcase}"
+            else
+              if named_parameters[parameteriteration] == nil
+                if sis == "N"
+                  mappedurl += "/:Integer"
+                elsif sis == "X"
+                  mappedurl += "/:String"
+                else
+                  puts "{sis}"
+                  mappedurl += "/#{sis}"
+                end
+              else
+                mappedurl += "/:#{named_parameters[parameteriteration]}"
+              end
+              parameteriteration += 1
+            end
+          }
+          mappedurl += "/"
+
+          # puts mappedurl
+          # puts "#{controller} - #{mappedurl}"
+          # message = "#{(normy(http_method))} - #{mappedurl}"
+          route = Route.new(http_method, controller.name, "App", mappedurl)
+
+          # puts route
+
+          mappedURLS.append route
+        }
+        mappedURLS
+      end
+
+      # Route Struct, for making and formatting a route from underlying data.
+      Route = Struct.new(:http_method, :controller, :app, :url)
+      class Route
+
+        # The width of the controller name
+        def width; @width ||= 0; end
+        def width=(value); @width = value; end
+
+        # The Actual controller name
+        def controller_name; @controller_name ||= ""; end
+        def controller_name=(value); @controller_name = value; end
+
+        # The Actual controller name
+        def the_url; @the_url ||= ""; end
+        def the_url=(value); @the_url = value; end
+
+        def message
+          pad
+          "#{controller_name} #{normy(http_method)} "
+          "/#{app.name.downcase}#{self.reverse_regex(route)}"
+        end
+
+        protected
+
+        # pad the controller name to be the right length, if we can.
+        def pad
+          if controller.length < width
+            @controller_name = @controller_name.ljust(width, " ")
+          end
+        end
+
+        def normy(themethod)
+          case themethod.to_s
+          when "post"
+            "POST  "
+          when "put"
+            "PUT   "
+          when "patch"
+            "PATCH "
+          when "delete"
+            "DELETE"
+          else
+            "GET   "
+          end
+        end
+
+      end
+
+      def parse
+        it = 0; routes = []
+        @parent_app::Apps.each { |app|
+          # puts app.name
+          if it == 0
+            app::X.constants.each { |controller|
+              contr_const = app::X.const_get(controller)
+
+              if (contr_const.respond_to? :urls) && !(contr_const.send :urls).empty?
+                # puts controller
+                puts "  urls:"
+                urls = contr_const.send :urls
+
+                urls.each { |url|
+                  puts url
+                }
+                routes.append(makeRoutes(app::X, controller)).flatten
+
+              else
+                routes.append(makeRoutes(app::X, controller)).flatten
+                puts routes
+              end
+              # puts " "
+              # return (k.method_defined?(m)) ?
+              # if contr_const.responds_to
+              #   c.respond_to? :urls
+
+              # puts contr_const.method_defined? :urls
+            }
+          else
+            app.routes.each { |route|
+              puts "  /#{app.name.downcase}#{self.reverse_regex(route)}"
+            }
+          end
+          it += 1
+        }
+      end
+
+      # takes a route string, which is regex and converts it to the defined Class in the App.
+      def reverse_regex(pattern)
+        nstr = "(\d+)"
+        xstr = "([^/]+)"
+
+        if pattern == "/"
+          "Index"
+        else
+          newpattern = ""
+          (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
+          newpattern
+        end
+
+      end
+
     end
+
+  end
+
+
+  class Commands
+
+    # A helper method to spit out Routes for an application
+    def self.routes()
+      # get all the routes?
+      # Camping::Apps[0]::Controllers.constants
+      # (Camping::Apps[0]::X.const_get :Pages).instance_methods false
+      Camping::CommandsHelpers::RoutesParser.parse(Camping)
+    end
+
   end
 end

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -7,21 +7,15 @@ module Camping
       # Assumes that Route structs are stored in :routes.
       def display
         current_app, current_method = "", ""
+        puts "App      VERB     Route"
         routes.each { |r|
-          # puts r
           if current_app != r.app.to_s
-            puts ""
             current_app = r.app.to_s
             current_method = ""
-            puts r.app_header
             puts "-----------------------------------"
+            puts r.app_header
           end
-          if current_method != r.http_method.to_s
-            current_method = r.http_method.to_s
-            puts r.padded_message true
-          else
-            puts r.padded_message
-          end
+          puts r.padded_message true
         }
       end
 
@@ -37,7 +31,7 @@ module Camping
 
       # pad the controller name to be the right length, if we can.
       def padded_message(with_method = false)
-        with_method ? "#{http_method.to_s.upcase.ljust(10, " ") } " + "#{url}" : "           " + "#{url}"
+        "#{pad}#{(with_method ? http_method.to_s.upcase.ljust(pad.length, " ") : pad)}#{replace_reg url}"
       end
 
       def app_header
@@ -45,13 +39,23 @@ module Camping
       end
 
       def controller_header
-        "           #{app.to_s}::#{controller.to_s}"
+        "#{pad}#{app.to_s}::#{controller.to_s}"
       end
 
       protected
 
       def http_methods
         ["get", "post", "put", "patch", "delete"]
+      end
+
+      def replace_reg(pattern = "")
+        xstr = "([^/]+)"; nstr = "(\d+)"
+        pattern = pattern.gsub(xstr, ":string").gsub("(\\d+)", ":integer") unless pattern == "/"
+        pattern
+      end
+
+      def pad
+        "         "
       end
 
     end
@@ -95,21 +99,6 @@ module Camping
         routes_collection = Camping::CommandsHelpers::RouteCollection.new(collected_routes)
       end
     end
-
-#       # takes a route string, which is regex and converts it to the defined Class in the App.
-#       def reverse_regex(pattern)
-#         nstr = "(\d+)"
-#         xstr = "([^/]+)"
-#
-#         if pattern == "/"
-#           "Index"
-#         else
-#           newpattern = ""
-#           (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
-#           newpattern
-#         end
-#
-#       end
 
   end
 

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -1,0 +1,8 @@
+module Camping
+  class Commands
+    def initialize(*args)
+      puts "Parsing Commands"
+      puts args
+    end
+  end
+end

--- a/lib/camping/commands.rb
+++ b/lib/camping/commands.rb
@@ -2,8 +2,8 @@ module Camping
   module CommandsHelpers
     class RoutesParser
 
-      def self.parse(app)
-        new(app).parse
+      def self.parse(app, silent)
+        new(app).parse silent
       end
 
       def initialize(app)
@@ -96,11 +96,17 @@ module Camping
 
       end
 
-      def parse
-        it = 0; routes = []
+      def parse(silent)
+        it = 0; routes = []; apps = []
+
+        if @parent_app.name == "Camping"
+          apps = @parent_app::Apps
+        else
+          apps.append @parent_app
+        end
 
         # Iterate over each app
-        @parent_app::Apps.each { |app|
+        apps.each { |app|
 
           prefix = ""; prefix = "/#{app.name.downcase}" unless it == 0
           appname = app.name.downcase
@@ -128,15 +134,17 @@ module Camping
           width = r.controller.length + 3 if r.controller.length > width
           appNameWidth = r.app.length + 3 if r.app.length > appNameWidth
         }
-        puts "#{"App".ljust(appNameWidth, " ")}#{"Controller".ljust(width, " ")} VERB     Route"
-        routes.each {|r|
-          if !appNames.include? r.app
-            puts "--------------------------------------"
-            puts "#{r.app.ljust(appNameWidth, " ")}".capitalize
-            appNames << r.app
-          end
-          puts r.padded_message(appNameWidth, width)
-        }
+        if silent != false
+          puts "#{"App".ljust(appNameWidth, " ")}#{"Controller".ljust(width, " ")} VERB     Route"
+          routes.each {|r|
+            if !appNames.include? r.app
+              puts "--------------------------------------"
+              puts "#{r.app.ljust(appNameWidth, " ")}".capitalize
+              appNames << r.app
+            end
+            puts r.padded_message(appNameWidth, width)
+          }
+        end
         routes
       end
 
@@ -149,7 +157,7 @@ module Camping
           "Index"
         else
           newpattern = ""
-          (pattern.gsub("([^/]+)", "X").gsub("(\d+)", "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
+          (pattern.gsub(xstr, "X").gsub(nstr, "N").split('/').each { |str| str.capitalize! }).each {|str| newpattern += str}
           newpattern
         end
 
@@ -162,8 +170,8 @@ module Camping
   class Commands
 
     # A helper method to spit out Routes for an application
-    def self.routes()
-      Camping::CommandsHelpers::RoutesParser.parse(Camping)
+    def self.routes(theApp = Camping, silent = false)
+      Camping::CommandsHelpers::RoutesParser.parse theApp, silent
     end
 
   end

--- a/lib/camping/mab.rb
+++ b/lib/camping/mab.rb
@@ -33,7 +33,7 @@ $MAB_CODE = %q{
   end
 }
 
-Camping::S.sub! /autoload\s*:Mab\s*,\s*['"]camping\/mab['"]/, $MAB_CODE
+Camping::S.sub!(/autoload\s*:Mab\s*,\s*['"]camping\/mab['"]/, $MAB_CODE)
 Camping::Apps.each do |c|
   c.module_eval $MAB_CODE
 end

--- a/lib/camping/reloader.rb
+++ b/lib/camping/reloader.rb
@@ -51,7 +51,7 @@ module Camping
       end
     end
 
-    # Loads the apps availble in this script.  Use <tt>apps</tt> to get
+    # Loads the apps available in this script.  Use <tt>apps</tt> to get
     # the loaded apps.
     def load_apps(old_apps)
       all_requires = $LOADED_FEATURES.dup

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -198,20 +198,6 @@ module Camping
       Rack::Cascade.new([Rack::Files.new(public_dir), self], [405, 404, 403])
     end
 
-    def current_app
-      @reloader.reload
-      apps = @reloader.apps
-      return apps.values.first if apps.size == 1
-      if key = apps.keys.grep(/^#{@reloader.name}$/i)[0]
-        apps[key]
-      end
-    end
-
-    def old_call(env)
-      app = current_app || raise("Could not find an app called `#{@reloader.name}`")
-      app.call(env)
-    end
-
     # path_matches?
     # accepts a regular expression string
     # in our case our apps and controllers

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -169,8 +169,6 @@ module Camping
 
       # If routes option was chosen to short circut here
       if options[:routes] == true
-        # Disable Verbose because we just want routes.
-        $VERBOSE = nil
         @reloader.reload!
         r = @reloader
         eval("self", TOPLEVEL_BINDING).meta_def(:reload!) { r.reload!; nil }

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -155,7 +155,7 @@ module Camping
     end
 
     def app
-      Rack::Cascade.new([Rack::File.new(public_dir), self], [405, 404, 403])
+      Rack::Cascade.new([Rack::Files.new(public_dir), self], [405, 404, 403])
     end
 
     # path_matches?

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -91,8 +91,7 @@ module Camping
           end
 
           # Show Routes
-          opts.on("-R", "--routes",
-          "Show Routes") { options[:routes] = true }
+          opts.on("-r", "--routes", "Show Routes") { options[:routes] = true }
 
           # Crude start at a generator
 #           opts.separator ""
@@ -170,6 +169,8 @@ module Camping
 
       # If routes option was chosen to short circut here
       if options[:routes] == true
+        # Disable Verbose because we just want routes.
+        $VERBOSE = nil
         @reloader.reload!
         r = @reloader
         eval("self", TOPLEVEL_BINDING).meta_def(:reload!) { r.reload!; nil }

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -90,6 +90,10 @@ module Camping
             exit
           end
 
+          # Show Routes
+          opts.on("-R", "--routes",
+          "Show Routes") { options[:routes] = true }
+
           # Crude start at a generator
 #           opts.separator ""
 #           opts.separator "Generators:"
@@ -163,6 +167,17 @@ module Camping
     end
 
     def start
+
+      # If routes option was chosen to short circut here
+      if options[:routes] == true
+        @reloader.reload!
+        r = @reloader
+        eval("self", TOPLEVEL_BINDING).meta_def(:reload!) { r.reload!; nil }
+        ARGV.clear
+        Camping::Commands.routes
+        exit
+      end
+
       if options[:server] == "console"
         puts "** Starting console"
         @reloader.reload!

--- a/lib/camping/session.rb
+++ b/lib/camping/session.rb
@@ -9,7 +9,7 @@ module Camping
   #    to store your application's data.
   #
   #   require 'camping/session'    # 1
-  #   
+  #
   #   module Nuts
   #     set :secret, "Oh yeah!"    # 2
   #     include Camping::Session   # 3
@@ -28,7 +28,6 @@ module Camping
     def self.included(app)
       key    = "#{app}.state".downcase
       secret = app.options[:secret] || [__FILE__, File.mtime(__FILE__)].join(":")
-      
       app.use Rack::Session::Cookie, :key => key, :secret => secret
     end
   end

--- a/lib/camping/template.rb
+++ b/lib/camping/template.rb
@@ -10,7 +10,7 @@ $TILT_CODE = %{
   Template = Tilt
 }
 
-Camping::S.sub! /autoload\s*:Template\s*,\s*['"]camping\/template['"]/, $TILT_CODE
+Camping::S.sub!(/autoload\s*:Template\s*,\s*['"]camping\/template['"]/, $TILT_CODE)
 Camping::Apps.each do |c|
   c.module_eval $TILT_CODE
 end

--- a/lib/campingtrip.md
+++ b/lib/campingtrip.md
@@ -1,0 +1,341 @@
+# How does Camping work?
+This is an academic document written to help people, but mostly me, understand what Camping is doing and in what sequence. Why? Because I want to make camping better, but how do you make it better unless you understand what you've got?
+
+# Start
+Camping starts off with some simple code you type: `camping nuts.rb` into your terminal and the camping gem is loaded and executed. This assumes that you've installed camping via ruby gems: `gem install camping`. Gems are then given a binary command you can use on the command line, in our case **camping**. The camping command accepts a file as an argument and maybe some options. This command calls a *binary* that's found the camping gem, this is what it looks like:
+```ruby
+#!/usr/bin/env ruby
+
+$:.unshift File.dirname(__FILE__) + "/../lib"
+
+require 'camping'
+require 'camping/server'
+
+begin
+  Camping::Server.start
+rescue OptionParser::ParseError => ex
+  STDERR.puts "!! #{ex.message}"
+  puts "** use `#{File.basename($0)} --help` for more details..."
+  exit 1
+end
+```
+
+First wee see `$:.unshift File.dirname(__FILE__) + "/../lib"`, `$:`, is a global variable, that contains the loadpath for scripts. Every ruby file is a script, you may be more familiar with `$LOAD_PATH` which is an alias for the `$:` global. Next `unshift` is an array method that prepends an item to the beginning of an array. `File` is a builtin ruby class that lets you work with files. `File.dirname(file)` returns a string of the complete file path of the file given, except for the file's name. In our case we're using `__FILE__` to return the current file name, which is the binary file in the camping gem. the last portion: `+ "/../lib"` appends the string to the directory path that we just got. All of this is done to ensure that the `lib` folder where all of camping's code resides is added to the script load path.
+
+Next we require camping:
+```ruby
+require 'camping'
+require 'camping/server'
+```
+
+Which loads camping and it's server code in to the current script context.
+
+```ruby
+  Camping::Server.start
+```
+
+The above code finally Starts the camping server. So let's take a look at the server:
+
+```ruby
+require 'irb'
+require 'erb'
+require 'rack'
+require 'camping/reloader'
+require 'camping/commands'
+
+# == The Camping Server (for development)
+#
+# Camping includes a pretty nifty server which is built for development.
+# It follows these rules:
+#
+# * Load all Camping apps in a file.
+# * Mount those apps according to their name. (e.g. Blog is mounted at /blog.)
+# * Run each app's <tt>create</tt> method upon startup.
+# * Reload the app if its modification time changes.
+# * Reload the app if it requires any files under the same directory and one
+#   of their modification times changes.
+# * Support the X-Sendfile header.
+#
+# Run it like this:
+#
+#   camping blog.rb          # Mounts Blog at /
+#
+# And visit http://localhost:3301/ in your browser.
+module Camping
+  class Server < Rack::Server
+    class Options
+      if home = ENV['HOME'] # POSIX
+        DB = File.join(home, '.camping.db')
+        RC = File.join(home, '.campingrc')
+      elsif home = ENV['APPDATA'] # MSWIN
+        DB = File.join(home, 'Camping.db')
+        RC = File.join(home, 'Campingrc')
+      else
+        DB = nil
+        RC = nil
+      end
+
+      HOME = File.expand_path(home) + '/'
+
+      def parse!(args)
+        args = args.dup
+
+        options = {}
+
+        opt_parser = OptionParser.new("", 24, '  ') do |opts|
+          opts.banner = "Usage: camping my-camping-app.rb"
+          opts.define_head "#{File.basename($0)}, the microframework ON-button for ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE}) [#{RUBY_PLATFORM}]"
+          opts.separator ""
+          opts.separator "Specific options:"
+
+          opts.on("-h", "--host HOSTNAME",
+          "Host for web server to bind to (default is all IPs)") { |v| options[:Host] = v }
+
+          opts.on("-p", "--port NUM",
+          "Port for web server (defaults to 3301)") { |v| options[:Port] = v }
+
+          db = DB.sub(HOME, '~/') if DB
+          opts.on("-d", "--database FILE",
+          "SQLite3 database path (defaults to #{db ? db : '<none>'})") { |db_path| options[:database] = db_path }
+
+          opts.on("-C", "--console",
+          "Run in console mode with IRB") { options[:server] = "console" }
+
+          server_list = ["thin", "webrick", "console"]
+          opts.on("-s", "--server NAME",
+          "Server to force (#{server_list.join(', ')})") { |v| options[:server] = v }
+
+          opts.separator ""
+          opts.separator "Common options:"
+
+          # No argument, shows at tail.  This will print an options summary.
+          # Try it and see!
+          opts.on("-?", "--help", "Show this message") do
+            puts opts
+            exit
+          end
+
+          # Another typical switch to print the version.
+          opts.on("-m", "--mounting", "Shows Mounting Guide") do
+            puts "Mounting Guide"
+            puts ""
+            puts "To mount your horse, hop up on the side and put it."
+            exit
+          end
+
+          # Another typical switch to print the version.
+          opts.on("-v", "--version", "Show version") do
+            puts Gem.loaded_specs['camping'].version
+            exit
+          end
+
+        end
+
+        opt_parser.parse!(args)
+
+        # If no Arguments were called.
+        if args.empty?
+          args << "cabin.rb" # adds cabin.rb as a default camping entrance file
+        end
+
+        # Parses the first argument as the script to load into the server.
+        options[:script] = args.shift
+        options
+      end
+    end
+
+    def initialize(*)
+      super
+      @reloader = Camping::Reloader.new(options[:script]) do |app|
+        if !app.options.has_key?(:dynamic_templates)
+          app.options[:dynamic_templates] = true
+        end
+
+        if !Camping::Models.autoload?(:Base) && options[:database]
+          Camping::Models::Base.establish_connection(
+            :adapter => 'sqlite3',
+            :database => options[:database]
+          )
+        end
+      end
+    end
+
+    def opt_parser
+      Options.new
+    end
+
+    def default_options
+      super.merge({
+        :Port => 3301,
+        :database => Options::DB
+      })
+    end
+
+    def middleware
+      h = super
+      h["development"] << [XSendfile]
+      h
+    end
+
+    def start
+      if options[:server] == "console"
+        puts "** Starting console"
+        @reloader.reload!
+        r = @reloader
+        eval("self", TOPLEVEL_BINDING).meta_def(:reload!) { r.reload!; nil }
+        ARGV.clear
+        IRB.start
+        exit
+      else
+        name = server.name[/\w+$/]
+        puts "** Starting #{name} on #{options[:Host]}:#{options[:Port]}"
+        super
+      end
+    end
+
+    # defines the public directory to be /public
+    def public_dir
+      File.expand_path('../public', @reloader.file)
+    end
+
+    # add the public directory as a Rack app serving files first, then the
+    # current value of self, which is our camping apps, as an app.
+    def app
+      Rack::Cascade.new([Rack::Files.new(public_dir), self], [405, 404, 403])
+    end
+
+    # path_matches?
+    # accepts a regular expression string
+    # in our case our apps and controllers
+    def path_matches?(path, *reg)
+      reg.each do |r|
+        return true if Regexp.new(r).match? path
+      end
+      false
+    end
+
+    # call(env) res
+    # == How routing works
+    #
+    # The first app added using Camping.goes is set at the root, we walk through
+    # the defined routes of the first app to see if there is a match.
+    # With no match we then walk through every other defined app.
+    # Each subsequent app defined is loaded at a directory named after them:
+    #
+    #   camping.goes :Nuts          # Mounts Nuts at /
+    #   camping.goes :Auth          # Mounts Auth at /auth/
+    #   camping.goes :Blog          # Mounts Blog at /blog/
+    #
+    def call(env)
+      @reloader.reload
+      apps = @reloader.apps
+
+      # our switch statement iterates through possible app outcomes, no apps
+      # loaded, one app loaded, or multiple apps loaded.
+      case apps.length
+      when 0
+        [200, {'Content-Type' => 'text/html'}, ["I'm sorry but no apps were found."]]
+      when 1
+        apps.values.first.call(env) # When we have one
+      else
+        # 2 and up get special treatment
+        count = 0
+        apps.each do |name, app|
+          if count == 0
+            app.routes.each do |r|
+              if (path_matches?(env['PATH_INFO'], r))
+                next
+              end
+              return app.call(env) unless !(path_matches?(env['PATH_INFO'], r))
+            end
+          else
+            mount = name.to_s.downcase
+            case env["PATH_INFO"]
+            when %r{^/#{mount}}
+              env["SCRIPT_NAME"] = env["SCRIPT_NAME"] + $&
+              env["PATH_INFO"] = $'
+              return app.call(env)
+            when %r{^/code/#{mount}}
+              return [200, {'Content-Type' => 'text/plain', 'X-Sendfile' => @reloader.file}, []]
+            end
+          end
+          count += 1
+        end
+
+        # Just return the first app if we didn't find a match.
+        return apps.values.first.call(env)
+      end
+    end
+
+    class XSendfile
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+
+        if key = headers.keys.grep(/X-Sendfile/i).first
+          filename = headers[key]
+          content = open(filename,'rb') { | io | io.read}
+          headers['Content-Length'] = size(content).to_s
+          body = [content]
+        end
+
+        return status, headers, body
+      end
+
+      if "".respond_to?(:bytesize)
+        def size(str)
+          str.bytesize
+        end
+      else
+        def size(str)
+          str.size
+        end
+      end
+    end
+  end
+end
+```
+
+The beginning of Server loads the required code to get Camping started, and then opens the `Camping` module:
+
+```ruby
+module Camping
+  class Server < Rack::Server
+  end
+end
+```
+
+`Server` inherits from `Rack::Server`. Camping is Rack based to give ourselves a predictable interface for our web server code. Consequentally a lot of utilities useful for webservers are just baked into Rack, It gives Camping the chance to do what it does best, magic!
+
+The first class declared in `Server` is called `Options`. It's in charge of parsing the command line options supplied to camping, and then supplying those options as a hash for the program further down the line. This class is declared inside of the `Server` class so that we can encapsulate the behaviour of options within the server. Which is pretty nice. Next is initialize:
+
+```ruby
+def initialize(*)
+  super
+  @reloader = Camping::Reloader.new(options[:script]) do |app|
+    if !app.options.has_key?(:dynamic_templates)
+      app.options[:dynamic_templates] = true
+    end
+
+    if !Camping::Models.autoload?(:Base) && options[:database]
+      Camping::Models::Base.establish_connection(
+        :adapter => 'sqlite3',
+        :database => options[:database]
+      )
+    end
+  end
+end
+```
+
+`initialize` is the method called whenever you instantiate a new object of a class. You'll notice that the line of code in the method is a call to `super`. Because `Camping::Server` is a subclass of `Rack::Server`, and to get things rolling we first call `Rack::Server`'s initialize. Afterwards we setup the reloader, and optionally include the database.
+
+When you call super naked like that it passes along whatever arguments were sent to the method that called super. In our case It's a splat: `initialize(*)`, so everything is sent along.
+
+
+
+
+
+Remember earlier from the Camping binary where we start the server? : `Camping::Server.start`, You may notice that this is a call to a class method `start`, but we don't declare any class methods in `Camping::Server` only instance methods.

--- a/test/app_camping_gear.rb
+++ b/test/app_camping_gear.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+require 'camping'
+
+Camping.goes :Packing
+
+module Camping
+  module Gear
+
+    # Basically copied from Cuba, will probably modify later.
+    module CSRF
+
+      # Package Class Methods
+      module ClassMethods
+        # define class methods
+        def secret_token
+          @_secret_token ||= SecureRandom.base64(32)
+        end
+
+        def erase_token
+          @_secret_token = nil
+        end
+
+        def set_secret(secret)
+          @_secret_token = secret
+        end
+      end
+
+      # Run a setup routine with this Gear.
+      def self.setup(app)
+        @app = app
+        @app.set :secret_token, "top_secret_code"
+      end
+
+      # Adds an instance method csrf
+      def csrf
+        @csrf ||= Camping::Gear::CSRF::Helper.new(@state, @request)
+      end
+
+      class Helper
+        attr_accessor :req
+        attr_accessor :state
+
+        def initialize(state, request)
+          @state = state
+          @req = request
+        end
+      end
+    end
+  end
+end
+
+module Packing
+    pack Camping::Gear::CSRF
+end
+
+class Packing::Test < TestCase
+
+  def test_gear_packed
+    list = Packing::G
+    assert (list.length == 1), "Gear was not packed! Gear: #{list.length}"
+  end
+
+  def test_right_gear_packed
+    csrf_gear = Packing::G[0].to_s
+    assert (csrf_gear == "Camping::Gear::CSRF"), "The correct Gear was not packed! Gear: #{csrf_gear}"
+  end
+
+  def test_instance_methods_packed
+    im = Packing.instance_methods.map(&:to_s)
+    assert (im.include? "csrf"), "Gear instance methods were not included: #{im}"
+  end
+
+  def test_class_methods_packed
+    [:secret_token, :erase_token, :set_secret].each { |sym|
+      assert (Packing.methods.include? sym), "Gear class methods were not packed, missing #{sym.to_s}."
+    }
+  end
+
+  def test_setup_callback
+    secret = Packing.options[:secret_token]
+    assert (secret == "top_secret_code"), "Gear setup callback failed: \"#{secret}\" should be \"top_secret_code\"."
+  end
+
+end

--- a/test/app_partials.rb
+++ b/test/app_partials.rb
@@ -38,9 +38,11 @@ end
 
 # Copy over all controllers
 module TiltPartials::Controllers
+  $VERBOSE = nil
   Partials::Controllers.constants.each do |const|
     const_set(const, Partials::Controllers.const_get(const).dup)
   end
+  $VERBOSE = 1
 end
 
 module Partials::Views

--- a/test/app_partials.rb
+++ b/test/app_partials.rb
@@ -38,11 +38,9 @@ end
 
 # Copy over all controllers
 module TiltPartials::Controllers
-  $VERBOSE = nil
   Partials::Controllers.constants.each do |const|
     const_set(const, Partials::Controllers.const_get(const).dup)
   end
-  $VERBOSE = 1
 end
 
 module Partials::Views

--- a/test/app_reloader.rb
+++ b/test/app_reloader.rb
@@ -37,7 +37,7 @@ class TestReloader < TestCase
   def test_counter
     assert_equal 1, $counter
   end
-  
+
   def test_forced_reload
     reloader.reload!
     assert_equal 2, $counter

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -31,10 +31,12 @@ class Routes::Test < TestCase
   end
 
   def test_routes_helper
-    routes = Camping::Commands.routes Camping::Apps[8]
+    #Make sure to call the route maker.
+    Camping.routes
+    routes = Camping::Commands.routes Camping::Apps[8], false
     assert_equal routes.count, 3, "Routes are not numbered correctly"
-    assert routes[0].to_s == "Index GET      /index", "Routes do not include /, #{routes[0].to_s}"
-    assert routes[1].to_s == "PageX GET      /page/:String", "Routes do not include /, #{routes[0].to_s}"
-    assert routes[2].to_s == "PageX POST     /page/:String", "Routes do not include /, #{routes[0].to_s}"
+    assert routes[0].to_s == "Index GET      /index", "Routes do not include: #{routes[0].to_s}"
+    assert routes[1].to_s == "PageX GET      /page/:String", "Routes do not include: #{routes[1].to_s}"
+    assert routes[2].to_s == "PageX POST     /page/:String", "Routes do not include: #{routes[2].to_s}"
   end
 end

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'camping'
+require 'camping/commands'
 
 Camping.goes :Routes
 
@@ -9,14 +10,31 @@ module Routes::Controllers
       R(Style)
     end
   end
-  
+
   class Style < R '/style\.css'
   end
+
+  class PageX
+      def get
+      end
+
+      def post
+      end
+  end
+
 end
 
 class Routes::Test < TestCase
   def test_backslash
     get '/'
     assert_body '/style.css'
+  end
+
+  def test_routes_helper
+    routes = Camping::Commands.routes Camping::Apps[8]
+    assert_equal routes.count, 3, "Routes are not numbered correctly"
+    assert routes[0].to_s == "Index GET      /index", "Routes do not include /, #{routes[0].to_s}"
+    assert routes[1].to_s == "PageX GET      /page/:String", "Routes do not include /, #{routes[0].to_s}"
+    assert routes[2].to_s == "PageX POST     /page/:String", "Routes do not include /, #{routes[0].to_s}"
   end
 end

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -32,11 +32,10 @@ class Routes::Test < TestCase
 
   def test_routes_helper
     collection = Camping::Commands.routes Camping::Apps[8], true
-    routes = collection.routes
-    puts routes
+    routes = collection.routes.map(&:to_s)
     assert_equal routes.count, 3, "Routes are not numbered correctly"
-    assert routes[0].to_s == "get: /page/([^/]+)", "Routes do not include: [#{routes[0].to_s}]"
-    assert routes[1].to_s == "post: /page/([^/]+)", "Routes do not include: [#{routes[1].to_s}]"
-    assert routes[2].to_s == "get: /", "Routes do not include: [#{routes[2].to_s}]"
+    assert (routes.include? "get: /page/([^/]+)"), "Routes do not include: [get: /page/([^/]+)]"
+    assert (routes.include? "post: /page/([^/]+)"), "Routes do not include: [post: /page/([^/]+)]"
+    assert (routes.include? "get: /"), "Routes do not include: [get: /]"
   end
 end

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -33,9 +33,10 @@ class Routes::Test < TestCase
   def test_routes_helper
     collection = Camping::Commands.routes Camping::Apps[8], true
     routes = collection.routes
+    puts routes
     assert_equal routes.count, 3, "Routes are not numbered correctly"
-    assert routes[0].to_s == "get: /page/([^/]+)", "Routes do not include: #{routes[0].to_s}"
-    assert routes[1].to_s == "post: /page/([^/]+)", "Routes do not include: #{routes[1].to_s}"
-    assert routes[2].to_s == "get: /", "Routes do not include: #{routes[2].to_s}"
+    assert routes[0].to_s == "get: /page/([^/]+)", "Routes do not include: [#{routes[0].to_s}]"
+    assert routes[1].to_s == "post: /page/([^/]+)", "Routes do not include: [#{routes[1].to_s}]"
+    assert routes[2].to_s == "get: /", "Routes do not include: [#{routes[2].to_s}]"
   end
 end

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -31,12 +31,11 @@ class Routes::Test < TestCase
   end
 
   def test_routes_helper
-    #Make sure to call the route maker.
-    Camping.routes
-    routes = Camping::Commands.routes Camping::Apps[8], false
+    collection = Camping::Commands.routes Camping::Apps[8], true
+    routes = collection.routes
     assert_equal routes.count, 3, "Routes are not numbered correctly"
-    assert routes[0].to_s == "Index GET      /index", "Routes do not include: #{routes[0].to_s}"
-    assert routes[1].to_s == "PageX GET      /page/:String", "Routes do not include: #{routes[1].to_s}"
-    assert routes[2].to_s == "PageX POST     /page/:String", "Routes do not include: #{routes[2].to_s}"
+    assert routes[0].to_s == "get: /page/([^/]+)", "Routes do not include: #{routes[0].to_s}"
+    assert routes[1].to_s == "post: /page/([^/]+)", "Routes do not include: #{routes[1].to_s}"
+    assert routes[2].to_s == "get: /", "Routes do not include: #{routes[2].to_s}"
   end
 end

--- a/test/app_route_generating.rb
+++ b/test/app_route_generating.rb
@@ -31,7 +31,7 @@ class Routes::Test < TestCase
   end
 
   def test_routes_helper
-    collection = Camping::Commands.routes Camping::Apps[8], true
+    collection = Camping::Commands.routes Camping::Apps[9], true
     routes = collection.routes.map(&:to_s)
     assert_equal routes.count, 3, "Routes are not numbered correctly"
     assert (routes.include? "get: /page/([^/]+)"), "Routes do not include: [get: /page/([^/]+)]"

--- a/test/app_sessions.rb
+++ b/test/app_sessions.rb
@@ -16,14 +16,14 @@ module Sessions::Controllers
       redirect R(Two)
     end
   end
-  
+
   class Two
     def get
       @state.two = 56
       redirect R(Three)
     end
   end
-  
+
   class Three
     def get
       @state.three = 99

--- a/test/app_simple.rb
+++ b/test/app_simple.rb
@@ -8,40 +8,40 @@ module Simple::Controllers
     def get
       "Hello World!"
     end
-    
+
     def post
       "Hello Post!"
     end
-    
+
     def custom
       "Hello Custom!"
     end
   end
-  
+
   class PostN
     def get(id)
       "Post ##{id}"
     end
   end
-  
+
   class MultipleComplexX
     def get(str)
       "Complex: #{str}"
     end
   end
-  
+
   class DateNNN
     def get(year, month, day)
       [year, month, day] * "-"
     end
   end
-  
+
   class Regexp < R '/ohmy/([a-f]+)'
     def get(value)
       value
     end
   end
-  
+
   class Optional < R '/optional', '/optional/([^/]+)'
     def get(value = "default")
       "Optional: #{value}"
@@ -60,44 +60,44 @@ class Simple::Test < TestCase
     get '/'
     assert_body "Hello World!"
     assert_equal "text/html", last_response.headers['Content-Type']
-    
+
     post '/'
     assert_body "Hello Post!"
   end
-  
+
   def test_post
     get '/post/1'
     assert_body "Post #1"
-    
+
     get '/post/2'
     assert_body "Post #2"
-    
+
     get '/post/2-oh-no'
     assert_status 404
   end
-  
+
   def test_complex
     get '/multiple/complex/Hello'
     assert_body "Complex: Hello"
   end
-  
+
   def test_date
     get '/date/2010/04/01'
     assert_body "2010-04-01"
   end
-  
+
   def test_regexp
     get '/ohmy/cafebabe'
     assert_body "cafebabe"
-    
+
     get '/ohmy/CAFEBABE'
     assert_status 404
   end
-  
+
   def test_optional
     get '/optional'
     assert_body "Optional: default"
-    
+
     get '/optional/override'
     assert_body "Optional: override"
   end

--- a/test/apps/migrations.rb
+++ b/test/apps/migrations.rb
@@ -4,92 +4,92 @@ Camping.goes :Migrations
 
 module Migrations
   module Models
-	class BadDude < Base; end
-	class TableCreation < V 1.0
-	  def self.up
-	    puts "FORCE THE TABLES"
-	    create_table BadDude.table_name, :force=>true do |t|
-	      t.string :name, :limit => 255
-		  t.integer :bad
-		  t.timestamps
-	    end
-	  end
-	  def self.down
-	    drop_table BadDude.table_name
-	  end
-	end
-	class StartingDudes < V 1.3
-	  def self.up
-	    puts "There is only one way to make sure Bruce is the baddest"
-	    BadDude.create :name => "Bruce", :bad => 1
-	    BadDude.create :name => "Bruce", :bad => 2
-	    BadDude.create :name => "Bruce", :bad => 5
-	  end
-	  def self.down
-	    BadDude.delete_by_name "Bruce"
-	  end
-	end
-	class WeNeedMoreDudes < V 2.7
-	  def self.up
-	    puts "Maybe a non Bruce would help our worst case scenario planning"
-	    BadDude.create :name => "Bob", :bad => 3
-	    BadDude.create :name => "Samantha", :bad => 3
-	  end
-	  def self.down
-	    BadDude.delete_by_name "Bob"
-		BadDude.delete_by_name "Samantha"
-	  end
-	end
-    class NoIMeanWeNeedBadderDudes < V 3.14159
-	  def self.up
-	    puts "just in case things get ugly"
-	    sam = BadDude.find_by_name "Samantha"
-        sam.bad = 9001
-	    sam.save
-	  end
-	  def self.down
-	    sam = BadDude.find_by_name "Samantha"
-		sam.bad = 3
-		sam.save
-	  end
-	end
-	class WaitWeShouldDoThisEarlier < V 3.11
-	  def self.up
-	    puts "for workgroups"
-	    bruce = BadDude.find_by_name "Bob"
-	    bruce.bad = 45
-	    bruce.save
-	  end
-	  def self.down
-	    bruce = BadDude.find_by_name "Bob"
-		bruce.bad = 3
-		bruce.save
-	  end
-	end
+		class BadDude < Base; end
+		class TableCreation < V 1.0
+	  	def self.up
+	    	puts "FORCE THE TABLES"
+	    	create_table BadDude.table_name, :force=>true do |t|
+	      	t.string :name, :limit => 255
+		  	t.integer :bad
+		  	t.timestamps
+	    	end
+	  	end
+	  	def self.down
+	    	drop_table BadDude.table_name
+	  	end
+		end
+		class StartingDudes < V 1.3
+	  	def self.up
+	    	puts "There is only one way to make sure Bruce is the baddest"
+	    	BadDude.create :name => "Bruce", :bad => 1
+	    	BadDude.create :name => "Bruce", :bad => 2
+	    	BadDude.create :name => "Bruce", :bad => 5
+	  	end
+	  	def self.down
+	    	BadDude.delete_by_name "Bruce"
+	  	end
+		end
+		class WeNeedMoreDudes < V 2.7
+	  	def self.up
+	    	puts "Maybe a non Bruce would help our worst case scenario planning"
+	    	BadDude.create :name => "Bob", :bad => 3
+	    	BadDude.create :name => "Samantha", :bad => 3
+	  	end
+	  	def self.down
+	    	BadDude.delete_by_name "Bob"
+			BadDude.delete_by_name "Samantha"
+	  	end
+		end
+		class NoIMeanWeNeedBadderDudes < V 3.14159
+			def self.up
+				puts "just in case things get ugly"
+				sam = BadDude.find_by_name "Samantha"
+				sam.bad = 9001
+				sam.save
+			end
+			def self.down
+				sam = BadDude.find_by_name "Samantha"
+				sam.bad = 3
+				sam.save
+			end
+		end
+		class WaitWeShouldDoThisEarlier < V 3.11
+	  	def self.up
+	    	puts "for workgroups"
+	    	bruce = BadDude.find_by_name "Bob"
+	    	bruce.bad = 45
+	    	bruce.save
+	  	end
+	  	def self.down
+	    	bruce = BadDude.find_by_name "Bob"
+				bruce.bad = 3
+				bruce.save
+	  	end
+		end
   end
   module Controllers
-    class Bad < R '/(\d+)?'
-	  def get enough
-	    @dudes = BadDude.all :conditions => ["bad >= ?", enough.to_i]
-		@howbad = enough
-		render :savethepresident
-	  end
-	end
+		class Bad < R '/(\d+)?'
+			def get enough
+				@dudes = BadDude.all :conditions => ["bad >= ?", enough.to_i]
+				@howbad = enough
+				render :savethepresident
+			end
+		end
   end
   module Views
-    def savethepresident
-	  h1.ohnoes "The President Has Been Kidnapped By #{@howbad} Ninjas!"
-	  if @dudes.empty?
-	    div "None of the dudes are bad enough to rescue him, We are doomed!"
-      else
-	    div "Please get the following dudes:"
-	    ul.dudes do
-	      @dudes.each do |dude|
-		    li.dude dude.name
-		  end
-	    end
-      end
-	end
+		def savethepresident
+			h1.ohnoes "The President Has Been Kidnapped By #{@howbad} Ninjas!"
+			if @dudes.empty?
+				diveq2 "None of the dudes are bad enough to rescue him, We are doomed!"
+			else
+				div "Please get the following dudes:"
+				ul.dudes do
+					@dudes.each do |dude|
+						li.dude dude.name
+					end
+				end
+			end
+		end
   end
 end
 def Migrations.create

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $:.unshift File.dirname(__FILE__) + '/../lib'
+$VERBOSE = nil
 
 begin
   require 'rubygems'
@@ -16,19 +17,19 @@ require 'rack/test'
 
 class TestCase < MiniTest::Test
   include Rack::Test::Methods
-    
+
   def self.inherited(mod)
     mod.app = Object.const_get(mod.to_s[/\w+/])
     super
   end
-  
+
   class << self
     attr_accessor :app
   end
-  
+
   def body() last_response.body end
   def app()  self.class.app     end
-    
+
   def assert_reverse
     begin
       yield
@@ -37,7 +38,7 @@ class TestCase < MiniTest::Test
       assert false, "Block didn't fail"
     end
   end
-    
+
   def assert_body(str)
     case str
     when Regexp
@@ -46,7 +47,7 @@ class TestCase < MiniTest::Test
       assert_equal(str.to_s, last_response.body.strip)
     end
   end
-  
+
   def assert_status(code)
     assert_equal(code, last_response.status)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ end
 
 require 'minitest/autorun'
 require 'rack/test'
+require "minitest/reporters"
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
 
 class TestCase < MiniTest::Test
   include Rack::Test::Methods


### PR DESCRIPTION
Hi Friends, 

I added a routes helper to Camping Core. This can aid in debugging, it will spit out which routes have been set. Usage:

In your shell: 
```bash
camping nuts.rb -C
```

In IRB:
```ruby
Camping.routes
 => ["/page/([^/]+)", "/pages", "/", "/page/([^/]+)/edit", "/auth", "/", "/auth/"] 
Nuts.routes
 => ["/page/([^/]+)", "/pages", "/", "/page/([^/]+)/edit"] 
```

I'm thinking about adding a command line utilities file to batch up generators and debuggers to keep them out of core.

I've also restored the ability to mount multiple apps. The Logic is thus:

1. The first App that you mount `Camping.goes :Nuts`, will be mounted at the root of the file structure. `/`
2. Each subsequent App will be mounted in a sub directory corresponding to their App name `Camping.goes :Auth` : `/auth/`
3. If No controller picks up a request then the first controller is mounted to handle errors.

I haven't tested this with static files yet. Although I haven't tested static files at all, so I should probably do that. 

Also Camping is now using 4095 of it's 4096 bytes. 

Please see #63 and #91 for discussion.

One thing that may not be good is that routes aren't sorted, and I'm pretty the routes helper just returns the routes of a controller directly, and not the routes as they are mounted in the hierarchy. Maybe some refinement is in order before this feature ships.