### PR TITLE
Improve Gear

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Camping, a Microframework
 
-Camping is a web framework which consistently stays at less than 4kB of code.
+Camping is a web framework which consistently stays at less than 5kB of code.
 You can probably view the complete source code on a single page. But, you
 know, it's so small that, if you think about it, what can it really do?
 

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -11,7 +11,8 @@ end;module Helpers;def R c,*g;p,h=
 x.scan(p).size==g.size&&/^#{x}\/?$/=~(x=g.inject(x){|x,a|x.sub p,U.escape((a.
 to_param rescue a))}.gsub(/\\(.)/){$1})};h.any?? u+"?"+U.build_query(h[0]):u
 end;def / p;p[0]==?/?@root+p : p end;def URL c='/',*a;c=R(c,*a) if c.respond_to?(
-:urls);c=self/c;c=@request.url[/.{8,}?(?=\/|$)/]+c if c[0]==?/;URI c end end
+:urls);c=self/c;c=@request.url[/.{8,}?(?=\/|$)/]+c if c[0]==?/;URI c end
+def app_name;"Camping"end end
 module Base;attr_accessor:env,:request,:root,:input,:cookies,:state,:status,
 :headers,:body;T={};L=:layout;def lookup n;T.fetch(n.to_sym){|k|t=Views.
 method_defined?(k)||(t=O[:_t].keys.grep(/^#{n}\./)[0]and Template[t].new{
@@ -38,20 +39,19 @@ def v;@r.map(&:urls);end;def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;
-module F;T= ->(u){return u unless u.respond_to? :last;u << "/" unless u.last == "/";u};
-A= ->(c,u,p){u.prepend("/"+p) unless c.to_s == "I"}end;N=H.new{|_,x|x.downcase}.
+module F;A= ->(c,u,p){u.prepend("/"+p) unless c.to_s == "I"}end;N=H.new{|_,x|x.downcase}.
 merge!("N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>'');def M(pr);def M(pr);end;constants.
 map{|c|k=const_get(c);k.send:include,C,X,Base,Helpers,Models
-@r=[k]+@r if @r-[k]==@r;k.meta_def(:urls){[F::T.(F::A.(k,"#{c.to_s.scan(/.[^A-Z]*/)
-.map(&N.method(:[]))*'/'}",pr))]}if !k.respond_to?:urls}end end;I=R()end;X=
+@r=[k]+@r if @r-[k]==@r;k.meta_def(:urls){[F::A.(k,"#{c.to_s.scan(/.[^A-Z]*/)
+.map(&N.method(:[]))*'/'}",pr)]}if !k.respond_to?:urls}end end;I=R()end;X=
 Controllers;class<<self;def routes;X.M O[:url_prefix];(Apps.map(&:routes)<<X.v).flatten;end;
 def call e;X.M O[:url_prefix];k,m,*a=X.D e["PATH_INFO"],e['REQUEST_METHOD'].
 downcase,e;k.new(e,m).service(*a).to_a;rescue;r500(:I,k,m,$!,:env=>e).to_a end
 def method_missing m,c,*a;X.M O[:url_prefix];h=Hash===a[-1]?a.pop: {};e=H[Rack::MockRequest.
 env_for('',h.delete(:env)||{})];k=X.const_get(c).new(e,m.to_s);h.each{|i,v|k.
 send"#{i}=",v};k.service(*a) end;def use*a,&b;m=a.shift.new(method(:call),*a,&b)
-meta_def(:call){|e|m.call(e)}end;def pack g;G<<g;include g;
-extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self)if g.respond_to?(:setup)end;
+meta_def(:call){|e|m.call(e)}end;def pack*a,&b;G<<g=a.shift;include g;
+extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self,*a,&b)if g.respond_to?(:setup)end;
 def gear;G end;def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -77,12 +77,12 @@ module Camping
           end
 
           # Another typical switch to print the version.
-          opts.on("-m", "--mounting", "Shows Mounting Guide") do
-            puts "Mounting Guide"
-            puts ""
-            puts "To mount your horse, hop up on the side and put it."
-            exit
-          end
+          # opts.on("-m", "--mounting", "Shows Mounting Guide") do
+          #   puts "Mounting Guide"
+          #   puts ""
+          #   puts "To mount your horse, hop up on the side and put it."
+          #   exit
+          # end
 
           # Another typical switch to print the version.
           opts.on("-v", "--version", "Show version") do

--- a/test/app_camping_gear.rb
+++ b/test/app_camping_gear.rb
@@ -26,7 +26,7 @@ module Camping
       end
 
       # Run a setup routine with this Gear.
-      def self.setup(app)
+      def self.setup(app, *a, &block)
         @app = app
         @app.set :secret_token, "top_secret_code"
       end


### PR DESCRIPTION
This minor update brings a few refinements:

## Gear
Packing gear now expects a splat of options, and a block:

```ruby
Camping.goes :Nuts

module Nuts 
  pack Mustache::Camping , :templates => "./nuts/views", :views => "./nuts/views"
end
```

The block is stored and passed, along with self and the options, to the plugin's setup command.

```ruby
plugin.setup(self, *a, &b)
```

self in this context is your Camping app. this gives you the chance to capture a reference to your app, inspect variables, make changes, or set options. The Plugin's methods are still included in your app, and it's ClassMethods are still conditionally extended into your Camping app. 

## New Helper: app_name
I've added a new helper to Camping: `app_name`. Here's the definition:

```ruby
def app_name;"Camping"end
```

It's just a string, with "Camping" as the value, which may seem silly, But the `Camping.goes` method takes a copy of Camping's source code, and replaces every instance of "Camping" with the name of the app that your making. So:
```ruby
Camping.goes :Nuts
Camping::Apps[0].app_name # the first app is Nuts
#=> "Nuts"
```

This provides a safe, post app creation way to inspect the name of the current app. Which is useful for Plugins.

## Removed Trailing Slash in URLs:
This is the solution to a subtle bug that I introduced by forcing every url to have a trailing slash. First, we probably shouldn't force a slash, but forcing a trailing slash was to solve a bug where very similar urls wouldn't be recognized by the router:

```
/auth/login # not recognized
/auth/login/ # recognized
```

The behaviour was odd so forcing a slash seemed like a good solution. But sometimes you don't want to have a trailing slash? to solve this behaviour I decided to keep some code in `Camping::Server` that adds a trailing slash to each url that doesn't have one, solely to match the requested URL with the possible URLs in your app. So in the above example, both urls are recognized.

This problem/solution becomes more interesting when you consider how Camping uses the R command to make controllers. The R Command maps a route to a controller, but bypasses the automatic route maker, so routes are exactly what you set them to be. There is probably a case to be made to improve the way that Camping makes and handles routes, but sort of improvements might those be?

## Hidden Mounting Guide
I hid the code for the mounting guide in the command line options. Mounting now works differently and keeping an empty guide didn't make sense. I'll take a detailed pass on this when more of the core documentation is up to speed.

## Additional Documentation in `camping-unabridged.rb`
I added some details about adding files to the end of your Camping file to Camping Unabridged. It's a topic that was not documented well, is a bit silly, but also very cool. I'll be covering this topic in the upcoming Documentation overhaul.

