### PR TITLE
Small syntax changes to avoid ambiguity.

### DIFF
--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -222,7 +222,7 @@ module Camping
     #   self / R(Edit, 1)   #=> "/blog/edit/1"
     #
     def /(p)
-      p[0] == ?/ ? @root + p : p #/
+      p[0] == ?/ ? (@root + p) : p #/
     end
 
     # Builds a URL route to a controller or a path, returning a URI object.
@@ -291,6 +291,13 @@ module Camping
 
           # Grab any settings set for the template files, as set by their filename extension
           # and add that to the options of Template (Tilt), or an empty Hash
+          # What does adding settings for a template look like? :
+          #   module Nuts
+          #     def r404(path)
+          #       @path = path
+          #       render :not_found
+          #     end
+          #   end
           Template.new(f, O[f[/\.(\w+)$/, 1].to_sym] || {})
 
         O[:dynamic_templates] ? t : T[k] = t

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -10,7 +10,7 @@ end;module Helpers;def R c,*g;p,h=
 /\(.+?\)/,g.grep(Hash);g-=h;raise"bad route"if !u=c.urls.find{|x|break x if
 x.scan(p).size==g.size&&/^#{x}\/?$/=~(x=g.inject(x){|x,a|x.sub p,U.escape((a.
 to_param rescue a))}.gsub(/\\(.)/){$1})};h.any?? u+"?"+U.build_query(h[0]):u
-end;def / p;p[0]==?/?@root+p : p end;def URL c='/',*a;c=R(c,*a) if c.respond_to?(
+end;def / p;p[0]==?/ ? (@root+p): p end;def URL c='/',*a;c=R(c,*a) if c.respond_to?(
 :urls);c=self/c;c=@request.url[/.{8,}?(?=\/|$)/]+c if c[0]==?/;URI c end
 def app_name;"Camping"end end
 module Base;attr_accessor:env,:request,:root,:input,:cookies,:state,:status,

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -54,7 +54,7 @@ meta_def(:call){|e|m.call(e)}end;def pack*a,&b;G<<g=a.shift;include g;
 extend g::ClassMethods if defined?(g::ClassMethods);g.setup(self,*a,&b)if g.respond_to?(:setup)end;
 def gear;G end;def options;O end;def set k,v;O[k]=v end
 def goes m,g=TOPLEVEL_BINDING;Apps<<a=eval(S.gsub(/Camping/,m.to_s),g);caller[0]=~/:/
-IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split /^@@\s*(.+?)\s*\r?\n/m).shift rescue nil
+IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split(/^@@\s*(.+?)\s*\r?\n/m)).shift rescue nil
 a.set :_t,H[*b||[]];end;end
 module Views;include X,Helpers end;module Models;autoload:Base,'camping/ar'
 Helpers.send:include,X,self end;autoload:Mab,'camping/mab'


### PR DESCRIPTION
Ruby sometimes complains in certain tests about having a `/` to close to a `?`, or having a regular expression too close to a `/` which we're overloading in Camping.

Also there was slight ambiguity and missing parentheses between `camping.rb` and `camping-unabridged.rb` in the code that loads embedded file definitions use `@@` and piling them into options: `O[:_t]`.