### PR TITLE
CI: Tell dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-20
   x86_64-darwin-23
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   kdl
@@ -72,4 +74,4 @@ DEPENDENCIES
   zeitwerk
 
 BUNDLED WITH
-   2.4.10
+   2.5.3


### PR DESCRIPTION
This PR adds a configuration to tell Dependabot to update the versions used for some well-known GitHub Actions, such as `checkout`, in order to avoid deprecation warnings when those get too old. [Documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

In addition: add platforms that are in use, to the `Gemfile.lock`.

Fixes #168