### PR TITLE
Improve Camping based on Who Wants to be Ruby Engineer at RubyConf

### DIFF
--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,7 +1,7 @@
 require "cam\ping/loads";E||="content-type";Z||="text/html"
 class Object;def meta_def m,&b;(class<<self;self
 end).define_method(m,&b) end;end
-module Camping;C=self;S=IO.read(__FILE__)rescue nil
+module Camping;C=self;S=IO.read(__FILE__)rescue()
 P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;Apps=[];SK="camping";G=[]
 class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m
 .to_s]:super end;undef id,type if ??==63;end;O=H.new;O[:url_prefix]=""
@@ -12,8 +12,8 @@ end
 module Helpers;def R c,*g;p,h=
 /\(.+?\)/,g.grep(Hash);g-=h;raise"bad route"if !u=c.urls.find{|x|break x if
 x.scan(p).size==g.size&&/^#{x}\/?$/=~(x=g.inject(x){|x,a|x.sub p,U.escape((a.
-to_param rescue a))}.gsub(CampTools.descape){$1})};h.any?? u+"?"+U.build_query(h[0]) : u
-end;def /(p) p[0]==?/ ?(@root+@url_prefix.dup.prepend("/").chop+p) : p end
+to_param rescue a))}.gsub(CampTools.descape){$1})};h.any?? u+??+U.build_query(h[0]) : u
+end;def /(p) p[0]==?/ ?(@root+@url_prefix.dup.prepend(?/).chop+p) : p end
 def URL c='/',*a;c=R(c,*a)if c.respond_to?(
 :urls);c=self/c;c=@request.url[/.{8,}?(?=\/|$)/]+c if c[0]==?/;URI c end
 def app_name;"Camping"end end
@@ -21,7 +21,7 @@ module Base;attr_accessor:env,:request,:root,:input,:cookies,:state,:status,
 :headers,:body,:url_prefix;T={};L=:layout
 def lookup n;T.fetch(n.to_sym){|k|t=Views.
 method_defined?(k)||(t=O[:_t].keys.grep(/^#{n}\./)[0]and Template[t].new{
-O[:_t][t]})||(f=Dir[[O[:views]||"views","#{n}.*"]*'/'][0])&&Template.
+O[:_t][t]})||(f=Dir[[O[:views]||"views","#{n}.*"]*?/][0])&&Template.
 new(f,O[f[/\.(\w+)$/,1].to_sym]||{});O[:dynamic_templates]?t: T[k]=t}end
 def render v,*a,&b;if t=lookup(v);r=@_r;@_r=o=Hash===a[-1]?a.pop: {};s=(t==true)?mab{
 send v,*a,&b}: t.render(self,o[:locals]||{},&b);s=render(L,o.merge(L=>false)){s
@@ -40,7 +40,7 @@ def initialize env,m,p
 r=@request=Rack::Request.new(@env=env);@root,@input,@cookies,@state,@headers,
 @status,@method,@url_prefix=r.script_name.sub(/\/$/,''),n(r.params),
 Cookies[r.cookies],H[r.session[SK]||{}],{E=>Z},m=~/r(\d+)/?$1.to_i: 200,m,p
-@cookies._p=self/"/";end
+@cookies._p=self/?/;end
 def n h;Hash===h ?h.inject(H[]){|m,(k,v)|m[k]=n(v);m}: h end
 def service *a;r=catch(:halt){send(@method,*a)};@body||=r;self end end
 module Controllers;@r=[];class Camper end;class<<self
@@ -52,17 +52,17 @@ def D p,m,e;p='/'if
 !p||!p[0];(a=O[:_t].find{|n,_|n==p}) and return [I,:serve,*a]
 @r.map{|k|k.urls.map{|x|return(k.method_defined? m)?[k,m,*$~[1..-1].map{|x|U.unescape x}]:
 [I, 'r501',m]if p=~/^#{x}\/?$/}};[I,'r404',p] end;
-A=->(c,u,p){d=p.dup;d.chop! if u=='';u.prepend("/"+d) if !["I"].
+A=->(c,u,p){d=p.dup;d.chop! if u=='';u.prepend(?/+d) if ![?I].
 include? c.to_s
-if c.to_s=="Index";while d[-1]=="/";d.chop! end;u.prepend("/"+d)end;u}
-N=H.new{|_,x|x.downcase}.merge! "N"=>'(\d+)',"X"=>'([^/]+)',"Index"=>''
+if c.to_s=="Index";while d[-1]==?/;d.chop! end;u.prepend(?/+d)end;u}
+N=H.new{|_,x|x.downcase}.merge! ?N=>'(\d+)',?X=>'([^/]+)',"Index"=>''
 def M p;def M p;end
 constants.filter{|c|c.to_s!='Camper'}.map{|c|k=const_get(c);
 k.include(C,X,Base,Helpers,Models)
 @r=[k]+@r if @r-[k]==@r;mu=false;ka=k.ancestors
 if (k.respond_to?(:urls) && ka[1].respond_to?(:urls)) && (k.urls == ka[1].urls)
-mu = true unless ka[1].name == nil end
-k.meta_def(:urls){[A.(k,"#{c.to_s.scan(/.[^A-Z]*/).map(&N.method(:[]))*'/'}",p)]} if (!k
+mu = true unless ka[1].name == () end
+k.meta_def(:urls){[A.(k,"#{c.to_s.scan(/.[^A-Z]*/).map(&N.method(:[]))*?/}",p)]} if (!k
 .respond_to?(:urls) || mu==true)};end end;I=R()end;X=Controllers
 class<<self;def make_camp;X.M prx;Apps.map(&:make_camp) end;def routes;(Apps.map(&:routes)<<X.v).flatten end
 def prx;@_prx||=CampTools.normalize_slashes(O[:url_prefix])end
@@ -74,12 +74,12 @@ k.send"#{i}=",v};k.service(*a)end
 def use*a,&b;m=a.shift.new(method(:call),*a,&b);meta_def(:call){|e|m.call(e)};m;end
 def pack*a,&b;G<< g=a.shift;include g;g.setup(self,*a,&b)end
 def gear;G end;def options;O;end;def set k,v;O[k]=v end
-def goes m,g=TOPLEVEL_BINDING;sp=caller[0].split('`')[0].split(":");fl,ln=
+def goes m,g=TOPLEVEL_BINDING;sp=caller[0].split(?`)[0].split(?:);fl,ln=
 sp[0]+' <Cam\ping App> ',sp[1].to_i;Apps<< a=eval(S.gsub(/Camping/,m.to_s),g,fl,1);caller[0]=~/:/
 IO.read(a.set:__FILE__,$`)=~/^__END__/&&(b=$'.split(/^@@\s*(.+?)\s*\r?\n/m)
-).shift rescue nil;a.set :_t,H[*b||[]]
+).shift rescue();a.set :_t,H[*b||[]]
 a.set :_meta, H[file: fl, line_number: ln, parent: self,
-root: (name != "Cam\ping" ? '/' + CampTools.to_snake(name) : '/')];C.configure(a)end end
+root: (name != "Cam\ping" ? ?/ + CampTools.to_snake(name) : ?/)];C.configure(a)end end
 module Views;include X,Helpers end;module Models
 autoload :Base, 'camping/sequel'
 Helpers.include(X,self) end;autoload:Mab,'camping/mab'

--- a/test/app_goes_meta.rb
+++ b/test/app_goes_meta.rb
@@ -10,7 +10,7 @@ class Goesmeta::Test < TestCase
 		meta = value = options[:_meta]
 		value = "nil" if meta == nil
 		assert meta != nil, "meta data was not added. #{value}"
-		assert meta[:file].include?("/camping/camping/test/app_goes_meta.rb"), "Wait a minute. This app Goesmeta, has a wonky creation location. #{meta[:file]}"
+		assert meta[:file].include?("/test/app_goes_meta.rb"), "Wait a minute. This app Goesmeta, has a wonky creation location. #{meta[:file]}"
 		assert meta[:line_number] == 4, "App creation location line number is wrong. It's supposed to be 4."
 	end
 


### PR DESCRIPTION
No behavior change. Only a refactor. 

Reduces camping.rb by 20 characters

Before

```
camping-unabridged.rb :  33904  551%
           camping.rb :   5181   84%
```

After

```
camping-unabridged.rb :  33904  551%
           camping.rb :   5161   84%
```


Changes:

* Convert single character strings to `?` syntax
* Convert `nil` to `()` syntax
* Fix test that is coded for a specific project directory structure

Acknowledgements

* Thanks @DRBragg for inspiring my PR.
* Thanks @marcoroth for pairing on the changes.

Get your PR ready!
- [x] Name your PR something Snazzy.
- [x] Make certain that your PR passes the tests.
- [x] If you made any changes to `camping.rb`, or `camping-unabridged.rb` then make sure they are in sync.
- [x] If this is a Release PR, make sure that you updated the Camping version in `camping.gemspec`, `lib/version.rb`, and the `CHANGELOG`
- [x] Add a nice description of your changes in the CHANGELOG.
- [x] Delete any unnecessary commented out code that you thought you might need while working on the thing.
- [x] Rebase from main: `git checkout main; git pull upstream main, git checkout my_awesome_branch, git rebase main`.
- [x] Add a Description of your PR here.
- [x] Add a bulleted list with your changes.

When all that's done, Ask for a review from Karl.