### PR TITLE
It's not Ruby 1.8 anymore, use define_singleton_method

### DIFF
--- a/lib/camping-unabridged.rb
+++ b/lib/camping-unabridged.rb
@@ -16,9 +16,7 @@ E ||= "content-type"
 Z ||= "text/html"
 
 class Object #:nodoc:
-  def meta_def(m,&b) #:nodoc:
-    (class<<self;self end).define_method(m,&b)
-  end
+  alias meta_def define_singleton_method
 end
 
 # If you're new to Camping, you should probably start by reading the first

--- a/lib/camping.rb
+++ b/lib/camping.rb
@@ -1,6 +1,5 @@
 require "cam\ping/loads";E||="content-type";Z||="text/html"
-class Object;def meta_def m,&b;(class<<self;self
-end).define_method(m,&b) end;end
+class Object;alias meta_def define_singleton_method end
 module Camping;C=self;S=IO.read(__FILE__)rescue()
 P="<h1>Cam\ping Problem!</h1><h2>%s</h2>";U=Rack::Utils;Apps=[];SK="camping";G=[]
 class H<Hash;def method_missing m,*a;m.to_s=~/=$/?self[$`]=a[0]:a==[]?self[m


### PR DESCRIPTION
Get your PR ready!
- [X] Name your PR something Snazzy
- [X] Make certain that your PR passes the tests.
- [X] If you made any changes to `camping.rb`, or `camping-unabridged.rb` then make sure they are in sync.
- [X] If this is a Release PR, make sure that you updated the Camping version in `camping.gemspec`, `lib/version.rb`, and the `CHANGELOG`
- [ ] Add a nice description of your changes in the CHANGELOG. (doesn't look updated recently)
- [X] Delete any unnecessary commented out code that you thought you might need while working on the thing.
- [X] Rebase from main: `git checkout main; git pull upstream main, git checkout my_awesome_branch, git rebase main`.
- [X] Add a Description of your PR here.
- [X] Add a bulleted list with your changes.

When all that's done, Ask for a review from Karl.

## Example

When _why wrote camping in Ruby 1.8, define_singleton_method had not been added to Ruby yet.  However, it's been available since Ruby 1.8, and using it shaves a few bytes.  We could probably shave a few more by using a shorter version of meta_def (e.g. md), but that would be more invasive.

Changes:
* Use define_singleton_method

May I please have review, Karl? :)