### PR TITLE
Remove `String#bytesize` fallback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+= Unreleased
+* Remove `String#bytesize` fallback in Camping::Server.
+
 = 3.2.6
 09 Aug, 2024
 * Server now loads everything from the kindling directory. To start your fire.

--- a/lib/camping/server.rb
+++ b/lib/camping/server.rb
@@ -272,14 +272,8 @@ module Camping
         return status, headers, body
       end
 
-      if "".respond_to?(:bytesize)
-        def size(str)
-          str.bytesize
-        end
-      else
-        def size(str)
-          str.size
-        end
+      def size(str)
+        str.bytesize
       end
     end
   end


### PR DESCRIPTION
Ruby support the `bytesize` method on strings since 1.8.7: https://apidock.com/ruby/v1_8_7_72/String/bytesize This can probably be safely removed as we are using Ruby 3 syntax.

Get your PR ready!
- [ ] Name your PR something Snazzy.
- [x] Make certain that your PR passes the tests.
- [x] If you made any changes to `camping.rb`, or `camping-unabridged.rb` then make sure they are in sync.
- [x] If this is a Release PR, make sure that you updated the Camping version in `camping.gemspec`, `lib/version.rb`, and the `CHANGELOG`
- [x] Add a nice description of your changes in the CHANGELOG.
- [x] Delete any unnecessary commented out code that you thought you might need while working on the thing.
- [x] Rebase from main: `git checkout main; git pull upstream main, git checkout my_awesome_branch, git rebase main`.
- [x] Add a Description of your PR here.
- [x] Add a bulleted list with your changes.